### PR TITLE
Fix intensity definition

### DIFF
--- a/src/mozanalysis/metrics.py
+++ b/src/mozanalysis/metrics.py
@@ -120,7 +120,7 @@ class EngagementIntensity(MetricDefinition):
     columns = [F.col("sum_total_hours"), F.col("sum_active_hours")]
     aggregations = [
         F.expr(
-            "SUM(sum_total_hours) / ({hours_epsilon} + SUM(sum_active_hours))".format(
+            "SUM(sum_active_hours) / ({hours_epsilon} + SUM(sum_total_hours))".format(
                 **CONSTANTS
             )
         ).alias("intensity")

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -165,11 +165,11 @@ def test_engagement_metrics(spark):
         control=342 / (1 / 3600.0 + 35.625),
         variant=990 / (1 / 3600.0 + 103.125),
     )
-    # sum(total hours) / (1/3600 + sum(active hours))
+    # sum(active hours) / (1/3600 + sum(total hours))
     check_stat(
         "engagement_intensity",
-        control=4.75 / (1 / 3600.0 + 35.625),
-        variant=13.75 / (1 / 3600.0 + 103.125),
+        control=35.625 / (1 / 3600.0 + 4.75),
+        variant=103.125 / (1 / 3600.0 + 13.75),
     )
 
 


### PR DESCRIPTION
Per e.g.
https://metrics.mozilla.com/protected/sguha/shield_bootstrap.html,
intensity should be active_hours / total_hours, so that it ends up
generally being a fraction on [0, 1].