### PR TITLE
Don't unpersist the dataset

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+Next
+^^^^
+
+- ExperimentAnalysis.analyze no longer unpersists the dataset.
+
+
 2018.12.0 (2018-12-05)
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/mozanalysis/experiments.py
+++ b/src/mozanalysis/experiments.py
@@ -136,8 +136,6 @@ class ExperimentAnalysis(object):
                         }
                     )
 
-        dataset.unpersist()
-
         return pd.DataFrame(
             data,
             columns=[


### PR DESCRIPTION
Spark is smart about unpersisting on its own, and we may want to perform
additional computations on the cached data if we're working
interactively.