### PR TITLE
Work around unsafe fork in pyspark

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ skipsdist = True
 usedevelop = True
 extras = testing
 commands = pytest {posargs:tests/}
+setenv = OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
Touching core Objective C classes from a child process (in the case of
fork() without exec()) causes a defensive crash in recent versions of
macOS.

Pyspark forks unsafely, which triggers the defensive crash, which causes
tests to fail.

This doesn't fix anything -- it just disables the airbag -- but a proper
fix would have to land in pyspark.

Closes #40.