### PR TITLE
Keep using debian stretch (oldstable).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,16 +42,16 @@ jobs:
   py27:
     <<: *test_settings
     docker:
-      - image: python:2.7
+      - image: python:2.7-stretch
 
   py37:
     <<: *test_settings
     docker:
-      - image: python:3.7
+      - image: python:3.7-stretch
 
   lint:
     docker:
-      - image: python:2.7
+      - image: python:2.7-stretch
     steps:
     - checkout
     - run:
@@ -64,7 +64,7 @@ jobs:
   # below for trigger logic.
   deploy:
     docker:
-      - image: python:2.7
+      - image: python:2.7-stretch
     steps:
       - checkout
       - run:
@@ -86,7 +86,7 @@ jobs:
 
   docs: &docs_settings
     docker:
-      - image: python:3.7
+      - image: python:3.7-stretch
     steps:
       - checkout
       - run:


### PR DESCRIPTION
If you stand in one place long enough, the sands shift around you.

The package openjdk-8-jre-headless has been removed from the new debian (buster) and so the easiest short term fix for this is to stay on the old version.