### PR TITLE
Refactor time limits code in Experiment.

### DIFF
--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import attr
-from pyspark.sql import functions as F
+from pyspark.sql import Column, functions as F
 
 from mozanalysis.utils import add_days
 
@@ -144,6 +144,10 @@ class Experiment(object):
                 set ``num_dates_enrollment`` then do not set this; at best
                 it would be redundant, at worst it's contradictory.
 
+            debug_dupes (bool, optional): Include a column ``num_events``
+                giving the number of enrollment events associated with
+                the ``client_id`` and ``branch``.
+
         Returns:
             A Spark DataFrame of enrollment data. One row per
             enrollment. Columns:
@@ -151,6 +155,7 @@ class Experiment(object):
                 * client_id (str)
                 * enrollment_date (str): e.g. '20190329'
                 * branch (str)
+                * num_events (int, optional)
         """
         if callable(study_type):
             enrollments = study_type(spark)
@@ -187,7 +192,9 @@ class Experiment(object):
                     "'num_dates_enrollment'; you might contradict yourself."
                 )
             enrollments = enrollments.filter(
-                enrollments.enrollment_date <= self._get_scheduled_max_enrollment_date()
+                enrollments.enrollment_date <= add_days(
+                    self.start_date, self.num_dates_enrollment - 1
+                )
             )
         elif end_date is not None:
             enrollments = enrollments.filter(
@@ -285,19 +292,21 @@ class Experiment(object):
             in ``data_source`` - was agreed upon by the DS team, and is the
             standard format for queried experimental data.
         """
+        time_limits = TimeLimits.create(
+            self.start_date, last_date_full_data, analysis_start_days,
+            analysis_length_days, self.num_dates_enrollment
+        )
+
         for col in ['client_id', 'submission_date_s3']:
             if col not in data_source.columns:
                 raise ValueError("Column '{}' missing from 'data_source'".format(col))
 
-        req_dates_of_data = analysis_start_days + analysis_length_days
-
         enrollments = self.filter_enrollments_for_analysis_window(
-            enrollments, last_date_full_data, req_dates_of_data
+            enrollments, time_limits
         ).alias('enrollments')
 
         data_source = self.filter_data_source_for_analysis_window(
-            data_source, last_date_full_data, analysis_start_days,
-            analysis_length_days
+            data_source, time_limits
         ).alias('data_source')
 
         join_on = [
@@ -323,8 +332,8 @@ class Experiment(object):
                     - F.unix_timestamp(enrollments.enrollment_date, 'yyyyMMdd')
                 ) / (24 * 60 * 60)
             ).between(
-                analysis_start_days,
-                analysis_start_days + analysis_length_days - 1
+                time_limits.analysis_window_start,
+                time_limits.analysis_window_end
             ),
         ]
 
@@ -401,107 +410,28 @@ class Experiment(object):
             tssp.payload.addon_version.alias('addon_version'),
         )
 
-    def _get_scheduled_max_enrollment_date(self):
-        """Return the last enrollment date, according to the plan."""
-        assert self.num_dates_enrollment is not None
+    def filter_enrollments_for_analysis_window(self, enrollments, time_limits):
+        """Return ``enrollments``, filtered to the relevant dates.
 
-        return add_days(self.start_date, self.num_dates_enrollment - 1)
-
-    def _get_last_enrollment_date(self, last_date_full_data, req_dates_of_data):
-        """Return the date of the final used enrollment.
-
-        We need ``req_dates_of_data`` days of post-enrollment data per client.
-        This and ``last_date_full_data`` put constraints on the enrollment
-        period. This method checks these constraints are feasible, and
-        compatible with any manually supplied enrollment period.
-
-        If ``self.num_dates_enrollment`` is ``None``, then there is potential
-        for the final date to be surprising, so we print it.
-
-        Args:
-            last_date_full_data (str): The most recent date for which we
-                have complete data, e.g. '20190322'. If you want to ignore
-                all data collected after a certain date (e.g. when the
-                experiment recipe was deactivated), then do that here.
-            req_dates_of_data (int): The minimum number of dates of
-                post-enrollment data required to have data for the client
-                for the entire analysis window.
+        Ignore enrollments that were received after the enrollment
+        period (if one was specified), else ignore enrollments for
+        whom we do not have data for the entire analysis window.
         """
-        last_enrollment_with_data = add_days(
-            last_date_full_data, -(req_dates_of_data - 1)
-        )
-
-        if self.num_dates_enrollment is None:
-            if last_enrollment_with_data < self.start_date:
-                raise ValueError("No users have a complete analysis window")
-
-            print("Taking enrollments between {} and {}".format(
-                self.start_date, last_enrollment_with_data
-            ))
-
-            return last_enrollment_with_data
-
-        else:
-            intended_last_enrollment = self._get_scheduled_max_enrollment_date()
-
-            if last_enrollment_with_data < intended_last_enrollment:
-                raise ValueError(
-                    "You said you wanted {} dates of enrollment, ".format(
-                        self.num_dates_enrollment
-                    ) + "but your analysis window of {} days won't have ".format(
-                        req_dates_of_data
-                    ) + "complete data until we have the data for {}.".format(
-                        add_days(intended_last_enrollment, req_dates_of_data - 1)
-                    )
-                )
-
-            return intended_last_enrollment
-
-    def _get_last_data_date(self, last_date_full_data, req_dates_of_data):
-        """Return the date of the final used datum."""
-        last_enrollment_date = self._get_last_enrollment_date(
-            last_date_full_data, req_dates_of_data
-        )
-
-        last_required_data_date = add_days(
-            last_enrollment_date, req_dates_of_data - 1
-        )
-
-        # `_get_last_enrollment_date` should have checked for this
-        assert last_required_data_date <= last_date_full_data
-
-        return last_required_data_date
-
-    def filter_enrollments_for_analysis_window(
-        self, enrollments, last_date_full_data, req_dates_of_data
-    ):
-        """Return the enrollments, filtered to the relevant dates."""
         return enrollments.filter(
-            # Ignore clients without a complete analysis window
-            enrollments.enrollment_date <= self._get_last_enrollment_date(
-                last_date_full_data, req_dates_of_data
-            )
+            enrollments.enrollment_date <= time_limits.last_enrollment_date
         )
 
-    def filter_data_source_for_analysis_window(
-        self, data_source, last_date_full_data, analysis_start_days,
-        analysis_length_days
-    ):
+    def filter_data_source_for_analysis_window(self, data_source, time_limits):
         """Return ``data_source``, filtered to the relevant dates.
 
-        This should not affect the results - it should just speed things
-        up.
+        Ignore data before the analysis window of the first enrollment,
+        and after the analysis window of the last enrollment.  This
+        should not affect the results - it should just speed things up.
         """
         return data_source.filter(
-            # Ignore data before the analysis window of the first enrollment
-            data_source.submission_date_s3 >= add_days(
-                self.start_date, analysis_start_days
-            )
-        ).filter(
-            # Ignore data after the analysis window of the last enrollment,
-            # and data after the specified `last_date_full_data`
-            data_source.submission_date_s3 <= self._get_last_data_date(
-                last_date_full_data, analysis_start_days + analysis_length_days
+            data_source.submission_date_s3.between(
+                time_limits.first_date_data_required,
+                time_limits.last_date_data_required
             )
         )
 
@@ -534,3 +464,161 @@ class Experiment(object):
                 & F.isnull(data_source.experiments[self.experiment_slug])
             ).astype('int'), F.lit(0))).alias('has_non_enrolled_data'),
         ]
+
+
+@attr.s(frozen=True)
+class TimeLimits(object):
+    """Internal object containing various time limits.
+
+    Instantiated and used by the ``Experiment`` class; end users
+    should not need to interact with it.
+
+    Do not directly instantiate: use ``TimeLimits.create()``.
+
+    There are several time constraints needed to specify a valid query
+    for experiment data:
+
+        * When did enrollments start?
+        * When did enrollments stop?
+        * How long after enrollment does the analysis window start?
+        * How long is the analysis window?
+
+    Even if these four quantities are specified directly, it is
+    important to check that they are consistent with the available
+    data - i.e. that we have data for the entire analysis window for
+    every enrollment.
+
+    Furthermore, there are some extra quantities that are useful for
+    writing efficient queries:
+
+        * What is the first date for which we need data from our data
+          source?
+        * What is the last date for which we need data from our data
+          source?
+
+    Instances of this class store all these quantities and do validation
+    to make sure that they're consistent. The "store lots of overlapping
+    state and validate" strategy was chosen over "store minimal state
+    and compute on the fly" because different state is supplied in
+    different contexts.
+    """
+    first_enrollment_date = attr.ib(type=str)
+    last_enrollment_date = attr.ib(type=str)
+
+    analysis_window_start = attr.ib()
+    """The integer number of days between enrollment and the start of
+    the analysis window, represented either as an ``int`` or as a
+    Column of integers in the ``enrollments`` DataFrame."""
+
+    analysis_window_end = attr.ib()
+    """The integer number of days between enrollment and the end of
+    the analysis window, represented either as an ``int`` or as a
+    Column of integers in the ``enrollments`` DataFrame."""
+
+    analysis_window_length_dates = attr.ib(type=int)
+    """The number of dates in the analysis window"""
+
+    first_date_data_required = attr.ib(type=str)
+    last_date_data_required = attr.ib(type=str)
+
+    @classmethod
+    def create(
+        cls,
+        first_enrollment_date,
+        last_date_full_data,
+        analysis_start_days,
+        analysis_length_dates,
+        num_dates_enrollment=None,
+    ):
+        """Return a ``TimeLimits`` instance with the following parameters
+
+        Args:
+            first_enrollment_date (str): First date on which enrollment
+                events were received; the start date of the experiment.
+            last_date_full_data (str): The most recent date for which we
+                have complete data, e.g. '20190322'. If you want to ignore
+                all data collected after a certain date (e.g. when the
+                experiment recipe was deactivated), then do that here.
+            analysis_start_days (int): the start of the analysis window,
+                measured in 'days since the client enrolled'. We ignore data
+                collected outside this analysis window.
+            analysis_length_days (int): the length of the analysis window,
+                measured in days.
+            num_dates_enrollment (int, optional): Only include this many days
+                of enrollments. If ``None`` then use the maximum number of days
+                as determined by the metric's analysis window and
+                ``last_date_full_data``. Typically ``7n+1``, e.g. ``8``. The
+                factor '7' removes weekly seasonality, and the ``+1`` accounts
+                for the fact that enrollment typically starts a few hours
+                before UTC midnight.
+        """
+        analysis_end_days = analysis_start_days + analysis_length_dates - 1
+
+        if num_dates_enrollment is None:
+            last_enrollment_date = add_days(last_date_full_data, -analysis_end_days)
+
+        else:
+            last_enrollment_date = add_days(
+                first_enrollment_date, num_dates_enrollment - 1
+            )
+
+            if add_days(last_enrollment_date, analysis_end_days) > last_date_full_data:
+                raise ValueError(
+                    "You said you wanted {} dates of enrollment, ".format(
+                        num_dates_enrollment
+                    ) + "and need data from the {}th day after enrollment. ".format(
+                        analysis_end_days
+                    ) + "For that, you need to wait until we have data for {}.".format(
+                        last_enrollment_date
+                    )
+                )
+
+        first_date_data_required = add_days(first_enrollment_date, analysis_start_days)
+        last_date_data_required = add_days(last_enrollment_date, analysis_end_days)
+
+        tl = cls(
+            first_enrollment_date=first_enrollment_date,
+            last_enrollment_date=last_enrollment_date,
+            analysis_window_start=analysis_start_days,
+            analysis_window_end=analysis_end_days,
+            analysis_window_length_dates=analysis_length_dates,
+            first_date_data_required=first_date_data_required,
+            last_date_data_required=last_date_data_required
+        )
+        return tl
+
+    @first_enrollment_date.validator
+    def _validate_first_enrollment_date(self, attribute, value):
+        assert self.first_enrollment_date <= self.last_enrollment_date
+        assert self.first_enrollment_date <= self.first_date_data_required
+        assert self.first_enrollment_date <= self.last_date_data_required
+
+    @last_enrollment_date.validator
+    def _validate_last_enrollment_date(self, attribute, value):
+        assert self.last_enrollment_date <= self.last_date_data_required
+
+    @first_date_data_required.validator
+    def _validate_first_date_data_required(self, attribute, value):
+        assert self.first_date_data_required <= self.last_date_data_required
+
+    @analysis_window_start.validator
+    def _validate_analysis_window_start(self, attribute, value):
+        if not isinstance(self.analysis_window_start, Column):
+            assert not isinstance(self.analysis_window_end, Column)
+            assert self.analysis_window_start >= 0
+            assert self.first_date_data_required == add_days(
+                self.first_enrollment_date, self.analysis_window_start
+            )
+
+    @analysis_window_length_dates.validator
+    def _validate_analysis_window_length_dates(self, attribute, value):
+        assert self.analysis_window_length_dates >= 1
+
+    @analysis_window_end.validator
+    def _validate_analysis_window_end(self, attribute, value):
+        if not isinstance(self.analysis_window_end, Column):
+            assert self.analysis_window_end == \
+                self.analysis_window_start + self.analysis_window_length_dates - 1
+            assert self.last_date_data_required == add_days(
+                self.last_enrollment_date, self.analysis_window_end
+            )

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -502,6 +502,7 @@ class TimeLimits(object):
     and compute on the fly" because different state is supplied in
     different contexts.
     """
+
     first_enrollment_date = attr.ib(type=str)
     last_enrollment_date = attr.ib(type=str)
 

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,85 +1,148 @@
 import pyspark.sql.functions as F
 import pytest
 
-from mozanalysis.experiment import Experiment
+from mozanalysis.experiment import Experiment, TimeLimits
 from mozanalysis.utils import add_days
 
 
-def test_get_last_enrollment_date():
-    exp = Experiment('a-stub', '20190101')
-    exp_8d = Experiment('experiment-with-8-day-cohort', '20190101', 8)
+def test_time_limits_validates():
+    # Mainly check that the validation is running at all
+    # No need to specify the same checks twice(?)
+    with pytest.raises(TypeError):
+        TimeLimits()
 
+    with pytest.raises(AssertionError):
+        TimeLimits(
+            first_enrollment_date='20190105',
+            last_enrollment_date='20190105',
+            analysis_window_start=1,
+            analysis_window_end=1,
+            analysis_window_length_dates=1,
+            first_date_data_required='20190101',  # Before enrollments
+            last_date_data_required='20190101',
+        )
+
+
+def test_time_limits_create1():
     # When we have complete data for 20190114...
-    the_fourteenth = '20190114'
-
     # ...We have 14 dates of data for those who enrolled on the 1st
-    exp._get_last_enrollment_date(the_fourteenth, 14) == '20190101'
+    tl = TimeLimits.create(
+        first_enrollment_date='20190101',
+        last_date_full_data='20190114',
+        analysis_start_days=0,
+        analysis_length_dates=14,
+    )
 
-    # We don't have 14 dates of data for the 8-day cohort:
+    assert tl.first_enrollment_date == '20190101'
+    assert tl.last_enrollment_date == '20190101'
+    assert tl.analysis_window_start == 0
+    assert tl.analysis_window_end == 13
+    assert tl.analysis_window_length_dates == 14
+    assert tl.first_date_data_required == '20190101'
+    assert tl.last_date_data_required == '20190114'
+
+
+def test_time_limits_create2():
+    # We don't have 14 dates of data for an 8-day cohort:
     with pytest.raises(ValueError):
-        exp_8d._get_last_enrollment_date(the_fourteenth, 14)
+        TimeLimits.create(
+            first_enrollment_date='20190101',
+            last_date_full_data='20190114',
+            analysis_start_days=0,
+            analysis_length_dates=14,
+            num_dates_enrollment=8,
+        )
 
     # We don't have 15 full dates of data for any users
-    with pytest.raises(ValueError):
-        exp._get_last_enrollment_date(the_fourteenth, 15)
+    with pytest.raises(AssertionError):
+        TimeLimits.create(
+            first_enrollment_date='20190101',
+            last_date_full_data='20190114',
+            analysis_start_days=0,
+            analysis_length_dates=15,
+        )
 
-    # And we certainly don't have 15 full dates for the 8-day cohort:
-    with pytest.raises(ValueError):
-        exp_8d._get_last_enrollment_date(the_fourteenth, 15)
 
+def test_time_limits_create3():
     # For the 8-day cohort We have enough data for a 7 day window
-    exp_8d._get_last_enrollment_date(the_fourteenth, 7) == '20190108'
+    tl = TimeLimits.create(
+        first_enrollment_date='20190101',
+        last_date_full_data='20190114',
+        analysis_start_days=0,
+        analysis_length_dates=7,
+        num_dates_enrollment=8,
+    )
+    assert tl.first_enrollment_date == '20190101'
+    assert tl.last_enrollment_date == '20190108'
+    assert tl.analysis_window_start == 0
+    assert tl.analysis_window_end == 6
+    assert tl.analysis_window_length_dates == 7
+    assert tl.first_date_data_required == '20190101'
+    assert tl.last_date_data_required == '20190114'
 
+
+def test_time_limits_create4():
     # Or a 2 day window
-    exp_8d._get_last_enrollment_date(the_fourteenth, 2) == '20190108'
+    tl = TimeLimits.create(
+        first_enrollment_date='20190101',
+        last_date_full_data='20190114',
+        analysis_start_days=0,
+        analysis_length_dates=2,
+        num_dates_enrollment=8,
+    )
+    assert tl.first_enrollment_date == '20190101'
+    assert tl.last_enrollment_date == '20190108'
+    assert tl.analysis_window_start == 0
+    assert tl.analysis_window_end == 1
+    assert tl.analysis_window_length_dates == 2
+    assert tl.first_date_data_required == '20190101'
+    assert tl.last_date_data_required == '20190109'
 
+
+def test_time_limits_create5():
     # But not an 8 day window
     with pytest.raises(ValueError):
-        exp_8d._get_last_enrollment_date(the_fourteenth, 8)
+        TimeLimits.create(
+            first_enrollment_date='20190101',
+            last_date_full_data='20190114',
+            analysis_start_days=0,
+            analysis_length_dates=8,
+            num_dates_enrollment=8,
+        )
 
+
+def test_time_limits_create6():
     # Of course the flexi-experiment has data for a 1 day window
-    exp._get_last_enrollment_date(the_fourteenth, 1) == '20190114'
+    tl = TimeLimits.create(
+        first_enrollment_date='20190101',
+        last_date_full_data='20190114',
+        analysis_start_days=0,
+        analysis_length_dates=1,
+    )
+    assert tl.first_enrollment_date == '20190101'
+    assert tl.last_enrollment_date == '20190114'
+    assert tl.analysis_window_start == 0
+    assert tl.analysis_window_end == 0
+    assert tl.analysis_window_length_dates == 1
+    assert tl.first_date_data_required == '20190101'
+    assert tl.last_date_data_required == '20190114'
 
 
-def test_get_last_data_date1():
-    exp = Experiment('a-stub', '20190101')
-
-    # When we have complete data for 20190114...
-    the_fourteenth = '20190114'
-
-    # When we don't specify num_days_enrollment we'll use all the data
-    assert exp._get_last_data_date(the_fourteenth, 14) == the_fourteenth
-    assert exp._get_last_data_date(the_fourteenth, 10) == the_fourteenth
-    assert exp._get_last_data_date(the_fourteenth, 1) == the_fourteenth
-    assert exp._get_last_data_date(the_fourteenth, 5) == the_fourteenth
-
-    # But we don't have 15 full dates of data for any users
-    with pytest.raises(ValueError):
-        exp._get_last_data_date(the_fourteenth, 15)
-
-
-def test_get_last_data_date2():
-    exp_8d = Experiment('experiment-with-8-day-cohort', '20190101', 8)
-
-    the_fourteenth = '20190114'
-
-    with pytest.raises(ValueError):
-        assert exp_8d._get_last_data_date(the_fourteenth, 14) == the_fourteenth
-
-    with pytest.raises(ValueError):
-        assert exp_8d._get_last_data_date(the_fourteenth, 10) == the_fourteenth
-
-    # If we only need 1 date of data then the final enrollment is fixed:
-    assert exp_8d._get_last_data_date(the_fourteenth, 1) == '20190108'
-    assert exp_8d._get_last_data_date('20190131', 1) == '20190108'
-    assert exp_8d._get_last_data_date('20201231', 1) == '20190108'
-
-    # And it's fixed to the date of the final enrollment
-    assert exp_8d._get_last_data_date(the_fourteenth, 1) \
-        == '20190108' \
-        == exp_8d._get_last_enrollment_date(the_fourteenth, 1)
-
-    assert exp_8d._get_last_data_date(the_fourteenth, 5) == '20190112'
+def test_time_limits_create7():
+    # If the analysis starts later, so does the data source
+    tl = TimeLimits.create(
+        first_enrollment_date='20190101',
+        last_date_full_data='20190114',
+        analysis_start_days=7,
+        analysis_length_dates=1,
+    )
+    assert tl.first_enrollment_date == '20190101'
+    assert tl.last_enrollment_date == '20190107'
+    assert tl.analysis_window_start == 7
+    assert tl.analysis_window_end == 7
+    assert tl.analysis_window_length_dates == 1
+    assert tl.first_date_data_required == '20190108'
+    assert tl.last_date_data_required == '20190114'
 
 
 def _get_data_source(spark):
@@ -126,19 +189,35 @@ def test_filter_data_source_for_analysis_window(spark):
     assert _simple_return_agg_date(F.min, data_source) < start_date
     assert _simple_return_agg_date(F.max, data_source) > end_date
 
-    filtered_ds = exp_8d.filter_data_source_for_analysis_window(
-        data_source, end_date, 0, 3
+    tl_03 = TimeLimits.create(
+        first_enrollment_date=exp_8d.start_date,
+        last_date_full_data=end_date,
+        analysis_start_days=0,
+        analysis_length_dates=3,
+        num_dates_enrollment=exp_8d.num_dates_enrollment
     )
+    assert tl_03.first_date_data_required == start_date
+    assert tl_03.last_date_data_required == '20190110'
 
-    assert _simple_return_agg_date(F.min, filtered_ds) == start_date
-    assert _simple_return_agg_date(F.max, filtered_ds) == '20190110'
+    filtered_ds = exp_8d.filter_data_source_for_analysis_window(data_source, tl_03)
 
-    filtered_ds_2 = exp_8d.filter_data_source_for_analysis_window(
-        data_source, end_date, 2, 3
+    assert _simple_return_agg_date(F.min, filtered_ds) == tl_03.first_date_data_required
+    assert _simple_return_agg_date(F.max, filtered_ds) == tl_03.last_date_data_required
+
+    tl_23 = TimeLimits.create(
+        first_enrollment_date=exp_8d.start_date,
+        last_date_full_data=end_date,
+        analysis_start_days=2,
+        analysis_length_dates=3,
+        num_dates_enrollment=exp_8d.num_dates_enrollment
     )
+    assert tl_23.first_date_data_required == add_days(start_date, 2)
+    assert tl_23.last_date_data_required == '20190112'
 
-    assert _simple_return_agg_date(F.min, filtered_ds_2) == add_days(start_date, 2)
-    assert _simple_return_agg_date(F.max, filtered_ds_2) == '20190112'
+    f_ds_2 = exp_8d.filter_data_source_for_analysis_window(data_source, tl_23)
+
+    assert _simple_return_agg_date(F.min, f_ds_2) == tl_23.first_date_data_required
+    assert _simple_return_agg_date(F.max, f_ds_2) == tl_23.last_date_data_required
 
 
 def _get_enrollment_view(slug):
@@ -176,7 +255,17 @@ def test_filter_enrollments_for_analysis_window(spark):
     # With final data collected on '20190114', we have 7 dates of data
     # for 'cccc' enrolled on '20190108' but not for 'dddd' enrolled on
     # '20190109'.
-    fe = exp.filter_enrollments_for_analysis_window(enrollments, '20190114', 7)
+    tl = TimeLimits.create(
+        first_enrollment_date=exp.start_date,
+        last_date_full_data='20190114',
+        analysis_start_days=0,
+        analysis_length_dates=7,
+        num_dates_enrollment=exp.num_dates_enrollment
+    )
+    assert tl.last_enrollment_date == '20190108'
+    assert tl.analysis_window_end == 6
+
+    fe = exp.filter_enrollments_for_analysis_window(enrollments, tl)
     assert fe.count() == 3
 
 
@@ -303,7 +392,10 @@ def test_get_per_client_data_join(spark):
     assert bob_badtiming.first()['some_value'] == 0
     # Check that _filter_data_source_for_analysis_window didn't do the
     # heavy lifting above
-    fds = exp.filter_data_source_for_analysis_window(data_source, '20190114', 1, 3)
+    time_limits = TimeLimits.create(
+        exp.start_date, '20190114', 1, 3, exp.num_dates_enrollment
+    )
+    fds = exp.filter_data_source_for_analysis_window(data_source, time_limits)
     assert fds.filter(
         fds.client_id == 'bob-badtiming'
     ).select(


### PR DESCRIPTION
Our next priorities are to introduce a metrics library and support for querying time series of metrics data. Both of these things add complexity to the queries that get sent to Spark, and the code that builds them. Here we lay some groundwork for those features by disentangling some logic from the `Experiment` class.

Here we introduce the `TimeLimits` class: an instance of TimeLimits holds all the temporal information used when querying data for an `Experiment`. It contains the start and end of the enrollment period, the details about the analysis window, and the relevant date range for the data source.

Previously, we tried to hold minimal state and compute quantities on the fly. Instead, `TimeLimits` precomputes and stores all these variables, which is conceptually easier (particularly when we start specifying a different set of variables when working with time series). We ensure self-consistency by providing a constructor with a near-minimal set of arguments, and by using validators.