### PR TITLE
Further refactoring of Experiment class

### DIFF
--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -417,7 +417,8 @@ class Experiment(object):
             tssp.payload.addon_version.alias('addon_version'),
         )
 
-    def _process_enrollments(self, enrollments, time_limits):
+    @staticmethod
+    def _process_enrollments(enrollments, time_limits):
         """Return ``enrollments``, filtered to the relevant dates.
 
         Ignore enrollments that were received after the enrollment
@@ -428,7 +429,8 @@ class Experiment(object):
             enrollments.enrollment_date <= time_limits.last_enrollment_date
         )
 
-    def _process_data_source(self, data_source, time_limits):
+    @staticmethod
+    def _process_data_source(data_source, time_limits):
         """Return ``data_source``, filtered to the relevant dates.
 
         Ignore data before the analysis window of the first enrollment,

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -297,13 +297,9 @@ class Experiment(object):
             analysis_length_days, self.num_dates_enrollment
         )
 
-        enrollments = self._process_enrollments(
-            enrollments, time_limits
-        ).alias('enrollments')
+        enrollments = self._process_enrollments(enrollments, time_limits)
 
-        data_source = self._process_data_source(
-            data_source, time_limits
-        ).alias('data_source')
+        data_source = self._process_data_source(data_source, time_limits)
 
         join_on = self._get_join_conditions(enrollments, data_source, time_limits)
 
@@ -427,7 +423,7 @@ class Experiment(object):
         """
         return enrollments.filter(
             enrollments.enrollment_date <= time_limits.last_enrollment_date
-        )
+        ).alias('enrollments')
 
     @staticmethod
     def _process_data_source(data_source, time_limits):
@@ -446,7 +442,7 @@ class Experiment(object):
                 time_limits.first_date_data_required,
                 time_limits.last_date_data_required
             )
-        )
+        ).alias('data_source')
 
     def _get_telemetry_sanity_check_metrics(self, enrollments, data_source):
         """Return aggregations that check for problems with a client."""

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -297,10 +297,6 @@ class Experiment(object):
             analysis_length_days, self.num_dates_enrollment
         )
 
-        for col in ['client_id', 'submission_date_s3']:
-            if col not in data_source.columns:
-                raise ValueError("Column '{}' missing from 'data_source'".format(col))
-
         enrollments = self.filter_enrollments_for_analysis_window(
             enrollments, time_limits
         ).alias('enrollments')
@@ -439,6 +435,10 @@ class Experiment(object):
         and after the analysis window of the last enrollment.  This
         should not affect the results - it should just speed things up.
         """
+        for col in ['client_id', 'submission_date_s3']:
+            if col not in data_source.columns:
+                raise ValueError("Column '{}' missing from 'data_source'".format(col))
+
         return data_source.filter(
             data_source.submission_date_s3.between(
                 time_limits.first_date_data_required,

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -297,11 +297,11 @@ class Experiment(object):
             analysis_length_days, self.num_dates_enrollment
         )
 
-        enrollments = self.filter_enrollments_for_analysis_window(
+        enrollments = self._process_enrollments(
             enrollments, time_limits
         ).alias('enrollments')
 
-        data_source = self.filter_data_source_for_analysis_window(
+        data_source = self._process_data_source(
             data_source, time_limits
         ).alias('data_source')
 
@@ -417,7 +417,7 @@ class Experiment(object):
             tssp.payload.addon_version.alias('addon_version'),
         )
 
-    def filter_enrollments_for_analysis_window(self, enrollments, time_limits):
+    def _process_enrollments(self, enrollments, time_limits):
         """Return ``enrollments``, filtered to the relevant dates.
 
         Ignore enrollments that were received after the enrollment
@@ -428,7 +428,7 @@ class Experiment(object):
             enrollments.enrollment_date <= time_limits.last_enrollment_date
         )
 
-    def filter_data_source_for_analysis_window(self, data_source, time_limits):
+    def _process_data_source(self, data_source, time_limits):
         """Return ``data_source``, filtered to the relevant dates.
 
         Ignore data before the analysis window of the first enrollment,

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -324,9 +324,15 @@ class Experiment(object):
     def _get_join_conditions(self, enrollments, data_source, time_limits):
         """Return a list of join conditions.
 
-        In ``_get_results_for_one_data_source``, we join ``enrollments``
-        to ``data_source``. This method returns the list of join
-        conditions.
+        Returns a list of boolean ``Column``s representing join
+        conditions between the ``enrollments`` ``DataFrame`` and
+        ``data_source``.
+
+        In ``_get_results_for_one_data_source``, we left join
+        ``enrollments`` to ``data_source`` using these join conditions
+        to produce a ``DataFrame`` containing the rows from
+        ``data_source`` for enrolled clients that were submitted during
+        the analysis window.
         """
         join_on = [
             # TODO perf: would it be faster if we enforce a join on sample_id?
@@ -420,6 +426,8 @@ class Experiment(object):
         Ignore enrollments that were received after the enrollment
         period (if one was specified), else ignore enrollments for
         whom we do not have data for the entire analysis window.
+
+        Name the returned ``DataFrame`` 'enrollments', for consistency.
         """
         return enrollments.filter(
             enrollments.enrollment_date <= time_limits.last_enrollment_date
@@ -432,6 +440,8 @@ class Experiment(object):
         Ignore data before the analysis window of the first enrollment,
         and after the analysis window of the last enrollment.  This
         should not affect the results - it should just speed things up.
+
+        Name the returned ``DataFrame`` 'data_source', for consistency.
         """
         for col in ['client_id', 'submission_date_s3']:
             if col not in data_source.columns:

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -326,8 +326,8 @@ class Experiment(object):
         )
         if keep_client_id:
             return res
-        else:
-            return res.drop(enrollments.client_id)
+
+        return res.drop(enrollments.client_id)
 
     def _get_join_conditions(self, enrollments, data_source, time_limits):
         """Return a list of join conditions.
@@ -372,7 +372,7 @@ class Experiment(object):
             join_on.append(
                 (enrollments.enrollment_date != F.col('submission_date_s3'))
                 | (~F.isnull(data_source.experiments[self.experiment_slug]))
-            ),
+            )
 
         return join_on
 

--- a/tests/bayesian_stats/test_consistency.py
+++ b/tests/bayesian_stats/test_consistency.py
@@ -60,9 +60,9 @@ def test_bayesian_bootstrap_vs_beta(spark_context):
     for l in boot_res.index:
         assert boot_res.loc[l] == pytest.approx(
             beta_res.loc[l],
-            # 1.9 is good enough with a percentile bootstrap
-            # abs=1.9/num_enrollments
-            abs=1.9/num_enrollments
+            # abs=1.9 is usually good enough with a percentile bootstrap
+            # set abs=2.9 because there are lots of tests
+            abs=2.9/num_enrollments
         ), (l, boot_res, beta_res)
 
 


### PR DESCRIPTION
Do more groundwork in preparation for supporting querying of time series and a metrics library.

Specifically, spin off the construction of the join conditions into a separate method so that `get_per_client_data()` fits on one screen and is easier to reason about.