### PR TITLE
Start a metrics library

### DIFF
--- a/docs/api/metrics.rst
+++ b/docs/api/metrics.rst
@@ -1,0 +1,5 @@
+:mod:`mozanalysis.metrics`
+-----------------------------
+
+.. automodule:: mozanalysis.metrics
+   :members:

--- a/docs/api/metrics/desktop.rst
+++ b/docs/api/metrics/desktop.rst
@@ -1,5 +1,4 @@
 :mod:`mozanalysis.metrics.desktop`
 ----------------------------------
 
-.. automodule:: mozanalysis.metrics.desktop
-   :members:
+See the source for the included metrics. Sphinx seems to be uncooperative displaying source code that does not define functions or classes - so view the latest source `on github <https://github.com/mozilla/mozanalysis/tree/master/src/mozanalysis/metrics/desktop.py>`_.

--- a/docs/api/metrics/desktop.rst
+++ b/docs/api/metrics/desktop.rst
@@ -1,0 +1,5 @@
+:mod:`mozanalysis.metrics.desktop`
+----------------------------------
+
+.. automodule:: mozanalysis.metrics.desktop
+   :members:

--- a/docs/api/metrics/firetv.rst
+++ b/docs/api/metrics/firetv.rst
@@ -1,5 +1,7 @@
 :mod:`mozanalysis.metrics.firetv`
 ----------------------------------
 
-.. automodule:: mozanalysis.metrics.firetv
-   :members:
+:mod:`mozanalysis.metrics.desktop`
+----------------------------------
+
+See the source for the included metrics. Sphinx seems to be uncooperative displaying source code that does not define functions or classes - so view the latest source `on github <https://github.com/mozilla/mozanalysis/tree/master/src/mozanalysis/metrics/firetv.py>`_.

--- a/docs/api/metrics/firetv.rst
+++ b/docs/api/metrics/firetv.rst
@@ -1,0 +1,5 @@
+:mod:`mozanalysis.metrics.firetv`
+----------------------------------
+
+.. automodule:: mozanalysis.metrics.firetv
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -184,3 +184,9 @@ epub_exclude_files = ['search.html']
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+
+# -- Autodoc configuration ---------------------------------------------------
+autodoc_default_options = {
+    'member-order': 'bysource'
+}

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1,0 +1,272 @@
+=====
+Guide
+=====
+
+Basic experiment: get the data & crunch the stats
+=================================================
+
+Let's start by analysing a straightforward pref-flip experiment on the desktop browser.
+
+If we're using Databricks, we begin by installing the latest version of :mod:`mozanalysis` into the notebook (we don't install for the whole cluster, because then upgrades require restarting the entire cluster)::
+
+    dbutils.library.installPyPI("mozanalysis", "[current version]")
+
+Then we import the necessary classes for getting the data, and for analysing the data::
+
+    import mozanalysis.metrics.desktop as mmd
+    import mozanalysis.bayesian_stats.binary as mabsbin
+    from mozanalysis.experiment import Experiment
+
+For querying data, the general approach of :mod:`mozanalysis` is to start by obtaining a list of who was enrolled in what branch, when. This list is the ``enrollments`` Spark DataFrame; it has one row per client. Then we try to quantify what happened to each client: for a given analysis window (a specified period of time defined with respect to the client's experiment results.date), we seek to obtain a value for each client for each metric. So we end up with a results (pandas) DataFrame with one row per client and one column per metric.
+
+
+We start by instantiating our :class:`mozanalysis.experiment.Experiment` object::
+
+    exp = Experiment(
+        experiment_slug='pref-flip-defaultoncookierestrictions-1506704',
+        start_date='20181217',
+        num_dates_enrollment=8
+    )
+
+``start_date`` is the ``submission_date_s3`` of the first enrollment (``submission_date_s3`` is in UTC). If you intended to study one week's worth of enrollments, then set ``num_dates_enrollment=8``: Normandy experiments typically go live in the evening UTC-time, so 8 days of data is a better approximation than 7.
+
+The :class:`mozanalysis.experiment.Experiment` instance has a method that gives us the ``enrollments`` Spark DataFrame. It's a good idea to cache it - we may use it multiple times::
+
+    enrollments = exp.get_enrollments(spark).cache()
+
+``enrollments`` has one row per enrolled client, and three columns::
+
+    >>> enrollments.columns
+    ['client_id', 'branch', 'enrollment_date']
+
+Having obtained our list of who was enrolled in what branch and when, we now try to quantify what happened to each client. In many cases, the metrics in which you're interested will already be in a metrics library, a submodule of :mod:`mozanalysis.metrics`. If not, then you can define your own - see :meth:`mozanalysis.metrics.Metric.from_col` and :meth:`mozanalysis.metrics.Metric.from_func` - and ideally submit a PR to add them to the library for the next experiment. In this example, we'll compute four metrics:
+
+* :const:`mozanalysis.metrics.desktop.active_hours`
+* uri count
+* ad clicks
+* search count
+
+As it happens, the first three metrics all come from the ``clients_daily`` dataset, whereas "search count" comes from ``search_clients_daily``. These details are taken care of in the :class:`mozanalysis.metrics.Metric` definitions so that we don't have to think about them here.
+
+A metric must be computed over some `analysis window`, a period of time defined with respect to the enrollment date. We could use :meth:`mozanalysis.experiment.Experiment.get_per_client_data()` to compute our metrics over a specific analysis window. But here, let's create time series data: let's have an analysis window for each of the first three weeks of the experiment, and measure the data for each of these analysis windows::
+
+    res = exp.get_time_series_data(
+        enrollments=enrollments,
+        metric_list=[
+            mmd.active_hours,
+            mmd.uri_count,
+            mmd.ad_clicks,
+            mmd.search_count,
+        ],
+        last_date_full_data='20190107',
+        time_series_period='weekly'
+    )
+
+The first two arguments to :meth:`mozanalysis.experiment.Experiment.get_time_series_data()` should be clear by this point. ``last_date_full_data`` is the last date for which we want to use data. For a currently-running experiment, it would typically be yesterday's date (we have incomplete data for incomplete days!). Here I chose a date that gives us two weeks of data for the last eligible enrollees, who enrolled on '20181224' (yes, this experiment ran over the holidays...).
+
+``time_series_period`` can be ``'daily'`` or ``'weekly'``. A ``'weekly'`` time series neatly sidesteps/masks weekly seasonality issues: most of the experiment subjects will enroll within a day of the experiment launching - typically a Tuesday, leading to ``'daily'`` time series reflecting a non-uniform convolution of the metrics' weekly seasonalities with the uneven enrollment numbers across the week.
+
+:meth:`mozanalysis.experiment.Experiment.get_time_series_data()` returns a ``dict`` keyed by the start of the analysis window (measured in days after enrollment)::
+
+    >>> res.keys()
+    dict_keys([0, 7])
+
+Each value is a pandas DataFrame in "the standard format", with one row per client from the ``enrollments`` Spark DataFrame, and one column per metric::
+
+    >>> res[7].columns
+     Index(['branch', 'enrollment_date', 'active_hours', 'uri_count',
+       'ad_clicks', 'clients_daily_has_contradictory_branch',
+       'clients_daily_has_non_enrolled_data', 'search_count',
+       'search_clients_daily_has_contradictory_branch',
+       'search_clients_daily_has_non_enrolled_data'],
+      dtype='object')
+
+The 'branch' column contains the client's branch::
+
+    >>> res[7].branch.unique()
+    array(['Cohort_1', 'Cohort_3', 'Cohort_2'], dtype=object)
+
+And we can do the usual pandas DataFrame things - e.g. calculate the mean active hours per branch::
+
+    >>> res[7].groupby('branch').active_hours.mean()
+    branch
+    Cohort_1    6.246536
+    Cohort_2    6.719880
+    Cohort_3    6.468948
+    Name: active_hours, dtype: float64
+
+Suppose we want to see whether the user had any active hours in their second week in the experiment. This information can be calculated from the ``mmd.active_hours`` metric - we add this as a column to the results pandas DataFrame, then use :mod:`mozanalysis.bayesian_stats.binary` to analyse this data::
+
+    res[7]['active_hours_gt_0'] = res[7]['active_hours'] > 0
+
+    retention_week_2 = mabsbin.compare_branches(res[7], 'active_hours_gt_0', ref_branch_label='Cohort_1')
+
+Like most of the stats in :mod:`mozanalysis`, :func:`mozanalysis.bayesian_stats.binary.compare_branches()` accepts a pandas DataFrame in "the standard format" and returns credible (or confidence) intervals for various quantities. It expects the reference branch to be named 'control'; since this experiment used non-standard branch naming, we need to tell it that the control branch is named 'Cohort_1'. The function returns credible intervals (CIs) for the fraction of active users in each branch.::
+
+    >>> retention_week_2['individual']
+    {'Cohort_1':
+         0.005    0.733865
+         0.025    0.734265
+         0.5      0.735536
+         0.975    0.736803
+         0.995    0.737201
+         mean     0.735535
+         dtype: float64,
+     'Cohort_2':
+         0.005    0.732368
+         0.025    0.732769
+         0.5      0.734041
+         0.975    0.735312
+         0.995    0.735710
+         mean     0.734041
+         dtype: float64,
+     'Cohort_3':
+         0.005    0.732289
+         0.025    0.732690
+         0.5      0.733962
+         0.975    0.735232
+         0.995    0.735630
+         mean     0.733962
+         dtype: float64}
+
+(output re-wrapped for clarity)
+
+For example, we can see that the fraction of users in Cohort_2 with >0 active hours in week 2 has an expectation value of 0.734, with a 95% CI of (0.7328, 0.7353).
+
+And the function also returns credible intervals for the uplift in this quantity for each branch with respect to a reference branch::
+
+    >>> retention_week_2['comparative']
+    {'Cohort_3':
+        rel_uplift    0.005   -0.005222
+                      0.025   -0.004568
+                      0.5     -0.002173
+                      0.975    0.000277
+                      0.995    0.001056
+                      exp     -0.002166
+        abs_uplift    0.005   -0.003850
+                      0.025   -0.003365
+                      0.5     -0.001598
+                      0.975    0.000204
+                      0.995    0.000774
+                      exp     -0.001594
+        max_abs_diff  0.95     0.003092
+        prob_win      NaN      0.041300
+        dtype: float64,
+     'Cohort_2':
+        rel_uplift    0.005   -0.005215
+                      0.025   -0.004502
+                      0.5     -0.002065
+                      0.975    0.000359
+                      0.995    0.001048
+                      exp     -0.002066
+        abs_uplift    0.005   -0.003840
+                      0.025   -0.003314
+                      0.5     -0.001520
+                      0.975    0.000264
+                      0.995    0.000769
+                      exp     -0.001520
+        max_abs_diff  0.95     0.003043
+        prob_win      NaN      0.046800
+        dtype: float64}
+
+(output re-wrapped for clarity)
+
+``rel_uplift`` contains quantities related to the relative uplift of a branch with respect to the reference branch (as given by ``ref_branch_label``); for example, assuming a uniform prior, there is a 95% probability that Cohort_3 had between 0.457% fewer and 0.028% more users with >0 active hours in the second week, compared to Cohort_1. ``abs_uplift`` refers to the absolute uplifts, and ``prob_win`` gives the probability that the branch is better than the reference branch.
+
+Since :mod:`mozanalysis` is designed around this "standard format", you can pass any of the values in ``res`` to any of the statistics functions, as long as the statistics are suited to the column's type (i.e. binary vs real-valued data)::
+
+    import mozanalysis.bayesian_stats.binary as mabsbin
+    retention_week_2 = mabsbin.compare_branches(res[7], 'active_hours_gt_0')
+
+    import mozanalysis.frequentist_stats.bootstrap as mafsboot
+    boot_uri_week_1 = mafsboot.compare_branches(res[0], 'uri_count', threshold_quantile=0.9999)
+
+    import mozanalysis.bayesian_stats.survival_func as mabssf
+    sf_search_week_2 = mabssf.compare_branches(res[7], 'search_count')
+
+:mod:`dscontrib.flawrence.plot_experiments` has some (shaky) support for visualising stats over time series experiment results.
+
+
+Get the data: cookbook
+=============================
+
+Time series (of analysis windows)
+---------------------------------
+Condensing the above example for simpler copying and pasting::
+
+    dbutils.library.installPyPI("mozanalysis", "[current version]")
+
+    import mozanalysis.metrics.desktop as mmd
+    from mozanalysis.experiment import Experiment
+
+    exp = Experiment(
+        experiment_slug='pref-flip-defaultoncookierestrictions-1506704',
+        start_date='20181217',
+        num_dates_enrollment=8
+    )
+
+    enrollments = exp.get_enrollments(spark).cache()
+
+    res = exp.get_time_series_data(
+        enrollments=enrollments,
+        metric_list=[
+            mmd.active_hours,
+        ],
+        last_date_full_data='20190107',
+        time_series_period='weekly'
+    )
+
+
+One analysis window
+-------------------
+
+If we're only interested in users' (say) second week in the experiment, then we don't need to get a full time series.
+::
+
+    dbutils.library.installPyPI("mozanalysis", "[current version]")
+
+    import mozanalysis.metrics.desktop as mmd
+    from mozanalysis.experiment import Experiment
+
+    exp = Experiment(
+        experiment_slug='pref-flip-defaultoncookierestrictions-1506704',
+        start_date='20181217',
+        num_dates_enrollment=8
+    )
+
+    enrollments = exp.get_enrollments(spark).cache()
+
+    res = exp.get_per_client_data(
+        enrollments=enrollments,
+        metric_list=[
+            mmd.active_hours,
+        ],
+        last_date_full_data='20190107',
+        analysis_start_days=7,
+        analysis_length_days=7
+    )
+
+``last_date_full_data`` is less important for :meth:`mozanalysis.experiment.Experiment.get_per_client_data` than for :meth:`mozanalysis.experiment.Experiment.get_time_series_data`: while ``last_date_full_data`` determines the length of the time series, here it simply sanity checks that the specified analysis window doesn't stretch into the future for any enrolled users.
+
+
+Crunch the stats
+================
+
+Each stats technique has a module in :mod:`mozanalysis.bayesian_stats` or :mod:`mozanalysis.frequentist_stats`, and a function ``compare_branches()``; for example :func:`mozanalysis.bayesian_stats.binary.compare_branches`. This function accepts a pandas DataFrame in "the standard format", and must be passed the name of the column containing the metric to be studied.
+::
+
+    import mozanalysis.bayesian_stats.binary as mabsbin
+    import mozanalysis.bayesian_stats.bayesian_bootstrap as mabsboot
+    import mozanalysis.bayesian_stats.survival_func as mabssf
+    import mozanalysis.frequentist_stats.bootstrap as mafsboot
+
+    ts_res[7]['active_hours_gt_0'] = ts_res[7].active_hours_gt_0 > 0
+    mabsbin.compare_branches(ts_res[7], 'active_hours_gt_0')
+    mabsbin.compare_branches(ts_res[7], 'active_hours_gt_0', ref_branch_label='Cohort_1')
+
+    gpcd_res['active_hours_gt_0'] = gpcd_res.active_hours_gt_0 > 0
+    mabsbin.compare_branches(gpcd_res, 'active_hours_gt_0')
+
+    mafsboot.compare_branches(gpcd_res, 'active_hours', threshold_quantile=0.9999)
+
+    sf_search_week_2 = mabssf.compare_branches(gpcd_res, 'search_count')

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -39,7 +39,7 @@ The :class:`mozanalysis.experiment.Experiment` instance has a method that gives 
     >>> enrollments.columns
     ['client_id', 'branch', 'enrollment_date']
 
-Having obtained our list of who was enrolled in what branch and when, we now try to quantify what happened to each client. In many cases, the metrics in which you're interested will already be in a metrics library, a submodule of :mod:`mozanalysis.metrics`. If not, then you can define your own - see :meth:`mozanalysis.metrics.Metric.from_col` and :meth:`mozanalysis.metrics.Metric.from_func` - and ideally submit a PR to add them to the library for the next experiment. In this example, we'll compute four metrics:
+Having obtained our list of who was enrolled in what branch and when, we now try to quantify what happened to each client. In many cases, the metrics in which you're interested will already be in a metrics library, a submodule of :mod:`mozanalysis.metrics`. If not, then you can define your own - see :meth:`mozanalysis.metrics.Metric` for examples - and ideally submit a PR to add them to the library for the next experiment. In this example, we'll compute four metrics:
 
 * :const:`mozanalysis.metrics.desktop.active_hours`
 * uri count

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-Welcome to mozanalysis's documentation!
+mozanalysis docs
 =======================================
 
 .. toctree::
@@ -7,8 +7,7 @@ Welcome to mozanalysis's documentation!
 
    about
 
-.. toctree::
-   :maxdepth: 1
+   guide
 
    api
 

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -646,6 +646,22 @@ class Experiment(object):
 
         return enrollments.alias('enrollments')
 
+    def _process_metrics(self, spark, metric_list):
+        """Return a dict of lists of Columns, representing metrics.
+
+        Each key is the DataFrame to which the Columns belong.
+        """
+        res = {}
+        for m in metric_list:
+            ds_df = m.data_source.get_dataframe(spark, self)
+
+            if ds_df not in res:
+                res[ds_df] = []  # This looks clunky but we're augmenting it soon
+
+            res[ds_df].append(m.get_col(spark, self))
+
+        return res
+
     @staticmethod
     def _process_data_source(data_source, time_limits):
         """Return ``data_source``, filtered to the relevant dates.

--- a/src/mozanalysis/metrics/__init__.py
+++ b/src/mozanalysis/metrics/__init__.py
@@ -1,0 +1,269 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import attr
+from pyspark.sql import functions as F
+
+
+@attr.s(frozen=True, slots=True)
+class DataSource(object):
+    """Wrapper for a Spark DataFrame.
+
+    This class is lazy: no Spark activity takes place until
+    ``get_dataframe()`` is called.
+
+    Examples:
+        There are three ways to instantiate a ``DataSource``::
+
+            clients_daily = DataSource.from_table_name('clients_daily')
+
+        or::
+
+            @DataSource.from_func()
+            def clients_daily(spark, experiment):
+                return spark.table('clients_daily')
+
+        or (for interactive use)::
+
+            clients_daily_df = spark.table('clients_daily')
+            clients_daily_ds = DataSource('clients_daily', clients_daily_df)
+
+    Avoid instantiating duplicate ``DataSource``s - if multiple metrics
+    require the same source of data but use different ``DataSource``
+    instances, then in some circumstances ``mozanalysis`` will not
+    recognise that the metrics could share a DataFrame, and Spark will
+    do extra work.
+    """
+    name = attr.ib(validator=attr.validators.instance_of(str))
+    _dataframe_getter = attr.ib(validator=attr.validators.is_callable())
+
+    @classmethod
+    def from_table_name(cls, name):
+        """Return a ``DataSource`` from a Spark table name.
+
+        Don't repeatedly call this with the same ``name``, because
+        we won't recognise that the different ``DataSource`` instances
+        are equal.
+
+        Args:
+            name (str): Supplied to ``spark.table()``
+
+        Example::
+
+            clients_daily = DataSource.from_table_name('clients_daily')
+        """
+        return cls(
+            name=name,
+            dataframe_getter=lambda spark, experiment: spark.table(name)
+        )
+
+    @classmethod
+    def from_func(cls):
+        """Decorator method to turn a function into a ``DataSource``.
+
+        The function must take two arguments: ``spark`` and
+        ``experiment``. The function's name is used as the
+        ``DataSource`` name.
+
+        Example::
+
+            from mozanalysis.experiment import Experiment
+            from pyspark.sql.session import SparkSession
+
+            DataSource.from_func()
+            def clients_daily(spark: SparkSession, experiment: Experiment):
+                return spark.table('clients_daily')
+        """
+        def f(dataframe_getter):
+            return cls(
+                name=dataframe_getter.__name__,
+                dataframe_getter=dataframe_getter
+            )
+
+        return f
+
+    @classmethod
+    def from_dataframe(cls, name, dataframe):
+        """Return a ``DataSource`` for a DataFrame.
+
+        Args:
+            name (str): Name for the ``DataSource``.
+            dataframe (DataFrame): The DataFrame to wrap.
+        """
+        return cls(
+            name=name,
+            dataframe_getter=lambda spark, experiment: dataframe
+        )
+
+    def get_dataframe(self, spark, experiment):
+        """Return the DataFrame for this ``DataSource``.
+
+        We cache the results so that repeated calls to
+        ``get_dataframe()`` return the same DataFrame, which makes it
+        easier to compute multiple metrics from one DataFrame. The
+        results are cached on the SparkSession, keyed by the
+        ``DataSource`` instance and the ``Experiment``.
+
+        Args:
+            spark (SparkSession): The SparkSession - in DataBricks this
+                is preloaded into every notebook as the variable
+                ``spark``.
+            experiment (Experiment): The Experiment being analysed. Some
+                ``DataSource``s require the experiment slug in order to
+                identify the correct data.
+        """
+        key = (self, experiment)
+        try:
+            return spark._MOZANALYSIS_DATA_SOURCE_CACHE[key]
+        except AttributeError:
+            spark._MOZANALYSIS_DATA_SOURCE_CACHE = {}
+        except KeyError:
+            pass
+
+        dataframe = self._dataframe_getter(spark, experiment)
+        spark._MOZANALYSIS_DATA_SOURCE_CACHE[key] = dataframe
+
+        return spark._MOZANALYSIS_DATA_SOURCE_CACHE[key]
+
+
+@attr.s(frozen=True, slots=True)
+class Metric(object):
+    """Represents an experiment metric.
+
+    Needs to be combined with an analysis window to be measurable!
+
+    Essentially this wraps a Spark Column and a reference to a
+    DataSource that can be used to obtain the DataFrame the column
+    belongs to.
+
+    These wrappers are needed in order for the metrics modules to be
+    lazy.
+
+    When defining metrics in the metric library, use the
+    ``Metric.from_func()`` decorator.
+
+    When defining metrics in interactive mode (i.e. in a notebook
+    where you already have the Spark Column and DataFrame, and
+    don't need to be lazy), use ``Metric.from_col()``.
+
+    Examples:
+        In the metrics library::
+
+            clients_daily = DataSource.from_table_name('clients_daily')
+
+            @Metric.from_func(clients_daily)
+            def active_hours(cd):
+                return agg_sum(cd.active_hours_sum)
+
+        In interactive mode::
+
+            cd = spark.table('clients_daily')
+
+            active_hours = Metric.from_col(
+                name='active_hours',
+                col=agg_sum(cd.active_hours_sum),
+                df_name='cd',
+                df=cd,
+            )
+    """
+    name = attr.ib(type=str)
+    data_source = attr.ib(validator=attr.validators.instance_of(DataSource))
+    _col_getter = attr.ib(type=callable)
+    description = attr.ib(type=str, default=None)
+
+    @classmethod
+    def from_func(cls, data_source):
+        """Decorator method to instantiate a ``Metric``.
+
+        Args:
+            data_source (DataSource): A ``DataSource`` that may be used
+                to obtain a DataFrame with the data required to compute
+                this ``Metric``.
+
+        The wrapped function needs to have one argument (the DataFrame
+        output by ``data_source.get_dataframe()``), and return a Column.
+        The function's name is taken as the ``Metric``'s name.
+
+        Example::
+
+            clients_daily = DataSource.from_table_name('clients_daily')
+
+            @Metric.from_func(clients_daily)
+            def active_hours(cd: DataFrame) -> Column:
+                return agg_sum(cd.active_hours_sum)
+        """
+        def f(col_getter):
+            return cls(
+                name=col_getter.__name__,
+                data_source=data_source,
+                col_getter=col_getter,
+                description=col_getter.__doc__
+            )
+
+        return f
+
+    @classmethod
+    def from_col(cls, metric_name, col, df_name, df):
+        """Return a ``Metric`` defined by ``col``.
+
+        Args:
+            metric_name (str): Name for the resulting Column.
+            col (Column): Spark Column representing the computed metric.
+            df_name (str): Name for the source DataFrame.
+            df (DataFrame): Source DataFrame, needed to compute Column.
+
+        Example::
+            cd = spark.table('clients_daily')
+
+            active_hours = Metric.from_col(
+                name='active_hours',
+                col=agg_sum(cd.active_hours_sum),
+                df_name='cd',
+                df=cd,
+            )
+        """
+        data_source = DataSource.from_dataframe(
+            name=df_name,
+            dataframe=df
+        )
+
+        return cls(
+            name=metric_name,
+            data_source=data_source,
+            col_getter=lambda _: col
+        )
+
+    def get_col(self, spark, experiment):
+        """Return a ``Column`` representing this metric.
+
+        Args:
+            spark (SparkSession): The Spark Session.
+            experiment (Experiment): The experiment for which this
+                metric is being computed.
+        """
+        # TODO: will this ever need access to ``enrollments``?
+        df = self.data_source.get_dataframe(spark, experiment)
+
+        try:
+            col = self._col_getter(df)
+        except TypeError:
+            col = self._col_getter(df, experiment)
+        return col.alias(self.name)
+
+
+def agg_sum(col):
+    """Return the sum over the data, with 0-filled nulls.
+
+    Args:
+        col (Column): A Spark Column of a numeric type
+    """
+    return F.coalesce(F.sum(col), F.lit(0))
+
+
+def agg_any(col):
+    """Return the bitwise OR, as an int, with 0-filled nulls.
+
+    Args:
+        col (Column): A Spark Column of bools
+    """
+    return F.coalesce(F.max(col).astype('int'), F.lit(0))

--- a/src/mozanalysis/metrics/__init__.py
+++ b/src/mozanalysis/metrics/__init__.py
@@ -28,7 +28,7 @@ class DataSource(object):
             clients_daily_df = spark.table('clients_daily')
             clients_daily_ds = DataSource('clients_daily', clients_daily_df)
 
-    Avoid instantiating duplicate ``DataSource``s - if multiple metrics
+    Avoid instantiating duplicate ``DataSource`` s - if multiple metrics
     require the same source of data but use different ``DataSource``
     instances, then in some circumstances ``mozanalysis`` will not
     recognise that the metrics could share a DataFrame, and Spark will
@@ -113,7 +113,7 @@ class DataSource(object):
                 is preloaded into every notebook as the variable
                 ``spark``.
             experiment (Experiment): The Experiment being analysed. Some
-                ``DataSource``s require the experiment slug in order to
+                ``DataSource`` s require the experiment slug in order to
                 identify the correct data.
         """
         key = (self, experiment)
@@ -267,6 +267,7 @@ class Metric(object):
                 DataFrame for the Column.
 
         Example::
+
             cd_ds = DataSource.from_table_name('clients_daily')
 
             active_hours = Metric.from_col(

--- a/src/mozanalysis/metrics/__init__.py
+++ b/src/mozanalysis/metrics/__init__.py
@@ -86,6 +86,10 @@ class DataSource(object):
     def from_dataframe(cls, name, dataframe):
         """Return a ``DataSource`` for a DataFrame.
 
+        Don't repeatedly call this with the same ``dataframe``, because
+        we won't recognise that the different ``DataSource`` instances
+        are equal.
+
         Args:
             name (str): Name for the ``DataSource``.
             dataframe (DataFrame): The DataFrame to wrap.
@@ -203,30 +207,24 @@ class Metric(object):
         return f
 
     @classmethod
-    def from_col(cls, metric_name, col, df_name, df):
+    def from_col(cls, metric_name, col, data_source):
         """Return a ``Metric`` defined by ``col``.
 
         Args:
             metric_name (str): Name for the resulting Column.
             col (Column): Spark Column representing the computed metric.
-            df_name (str): Name for the source DataFrame.
-            df (DataFrame): Source DataFrame, needed to compute Column.
+            data_source (DataSource): DataSource wrapper for the source
+                DataFrame for the Column.
 
         Example::
-            cd = spark.table('clients_daily')
+            cd_ds = DataSource.from_table_name('clients_daily')
 
             active_hours = Metric.from_col(
                 name='active_hours',
                 col=agg_sum(cd.active_hours_sum),
-                df_name='cd',
-                df=cd,
+                data_source=cd_ds
             )
         """
-        data_source = DataSource.from_dataframe(
-            name=df_name,
-            dataframe=df
-        )
-
         return cls(
             name=metric_name,
             data_source=data_source,

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -16,6 +16,12 @@ events = DataSource.from_table_name('events')
 
 @DataSource.from_func()
 def telemetry_shield_study_parquet(spark, experiment):
+    """DataSource commonly used with addon studies.
+
+    Used when we need to collect experiment-specific telemetry. We
+    filter to just include the data submitted by this experiment's
+    addon.
+    """
     tssp = spark.table('telemetry_shield_study_parquet')
 
     this_exp = tssp.filter(

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -32,6 +32,11 @@ def telemetry_shield_study_parquet(spark, experiment):
 
 @Metric.from_func(clients_daily)
 def active_hours(cd):
+    """Active hours, from ``active_ticks``
+
+    At any given moment, a client is "active" if there was a keyboard or
+    mouse interaction (click, scroll, move) in the previous 5 seconds.
+    """
     return agg_sum(cd.active_hours_sum)
 
 

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -1,0 +1,85 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# from pyspark.sql import functions as F
+
+from mozanalysis.metrics import Metric, DataSource, agg_sum, agg_any
+from mozanalysis.utils import all_  # , any_
+
+
+clients_daily = DataSource.from_table_name('clients_daily')
+main_summary = DataSource.from_table_name('main_summary')
+search_clients_daily = DataSource.from_table_name('search_clients_daily')
+events = DataSource.from_table_name('events')
+
+
+@DataSource.from_func()
+def telemetry_shield_study_parquet(spark, experiment):
+    tssp = spark.table('telemetry_shield_study_parquet')
+
+    this_exp = tssp.filter(
+        tssp.payload.study_name == experiment.experiment_slug
+    ).withColumnRenamed('submission', 'submission_date_s3')
+
+    if experiment.addon_version is None:
+        return this_exp
+    else:
+        return this_exp.filter(
+            tssp.payload.addon_version == experiment.addon_version
+        )
+
+
+@Metric.from_func(clients_daily)
+def active_hours(cd):
+    return agg_sum(cd.active_hours_sum)
+
+
+@Metric.from_func(search_clients_daily)
+def search_count(scd):
+    return agg_sum(scd.sap)
+
+
+@Metric.from_func(search_clients_daily)
+def ad_clicks(scd):
+    return agg_sum(scd.ad_click)
+
+
+@Metric.from_func(clients_daily)
+def uri_count(cd):
+    return agg_sum(cd.scalar_parent_browser_engagement_total_uri_count_sum)
+
+
+@Metric.from_func(events)
+def unenroll(events, experiment):
+    return agg_any(all_([
+        events.event_category == 'normandy',
+        events.event_method == 'unenroll',
+        events.event_string_value == experiment.experiment_slug,
+    ]))
+
+
+@Metric.from_func(telemetry_shield_study_parquet)
+def unenroll_addon_expt(tssp):
+    return agg_any(tssp.payload.data.study_state == 'exit')
+
+
+@Metric.from_func(search_clients_daily)
+def organic_search_count(scd):
+    return agg_sum(scd.organic)
+
+
+@Metric.from_func(events)
+def view_about_logins(events):
+    return agg_any(all_([
+        events.event_method == 'open_management',
+        events.event_category == 'pwmgr',
+    ]))
+
+
+@Metric.from_func(events)
+def view_about_protections(events):
+    return agg_any(all_([
+        events.event_object == 'protection_report',
+        events.event_method == 'show',
+    ]))

--- a/src/mozanalysis/metrics/firetv.py
+++ b/src/mozanalysis/metrics/firetv.py
@@ -1,0 +1,168 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from pyspark.sql import functions as F
+
+from mozanalysis.metrics import Metric, DataSource
+from mozanalysis.utils import all_, any_
+
+
+@DataSource.from_func()
+def firetv_events(spark, experiment):
+    te = spark.table('telemetry_mobile_event_parquet')
+    return te.filter(
+        te.app_name == 'FirefoxForFireTV'
+    ).select(
+      te.submission_date_s3,
+      te.client_id,
+      F.explode_outer(te.events).alias('event')
+    )
+
+
+@Metric.from_func(firetv_events)
+def user_show_menus(fe):
+    return F.sum(all_([
+        fe.event.category == 'action',
+        fe.event.method == 'user_show',
+        fe.event.object == 'menu',
+    ]).astype('int')),
+
+
+@Metric.from_func(firetv_events)
+def home_tile_clicks(fe):
+    return F.sum(all_([
+        fe.event.category == 'action',
+        fe.event.method == 'click',
+        fe.event.object == 'home_tile',
+
+        # Otherwise youtube is double counted (per liuche 2019/06/07) :'(
+        fe.event.value != 'youtube_tile'
+    ]).astype('int')),
+
+
+@Metric.from_func(firetv_events)
+def anything_but_youtube_tile_clicks(fe):
+    return F.sum(all_([
+        fe.event.category == 'action',
+        fe.event.method == 'click',
+        fe.event.object == 'home_tile',
+        fe.event.value != 'youtube_tile',
+        (
+            F.isnull(fe.event.extra['tile_id']) |
+            (fe.event.extra['tile_id'] != 'youtube')
+        )
+    ]).astype('int')),
+
+
+@Metric.from_func(firetv_events)
+def bundled_non_youtube_tile_clicks(fe):
+    return F.sum(all_([
+        fe.event.category == 'action',
+        fe.event.method == 'click',
+        fe.event.object == 'home_tile',
+        fe.event.value == 'bundled',
+        fe.event.extra['tile_id'] != 'youtube',
+    ]).astype('int')),
+
+
+@Metric.from_func(firetv_events)
+def pocket_video_clicks(fe):
+    return F.sum(all_([
+        fe.event.category == 'action',
+        fe.event.method == 'click',
+        fe.event.object == 'menu',
+        fe.event.value == 'pocket_video_tile'
+    ]).astype('int')),
+
+
+@Metric.from_func(firetv_events)
+def type_urls(fe):
+    return F.sum(all_([
+            fe.event.category == 'action',
+            fe.event.method == 'type_url',
+            fe.event.object == 'search_bar',
+        ]).astype('int')),
+
+
+@Metric.from_func(firetv_events)
+def type_queries(fe):
+    return F.sum(all_([
+        fe.event.category == 'action',
+        fe.event.method == 'type_query',
+        fe.event.object == 'search_bar',
+    ]).astype('int')),
+
+
+@Metric.from_func(firetv_events)
+def navigates_or_clicks_not_youtube(fe):
+    return F.sum(any_([
+        all_([
+            fe.event.category == 'action',
+            fe.event.method == 'click',
+            fe.event.object == 'home_tile',
+            fe.event.value != 'youtube_tile',
+            (
+                F.isnull(fe.event.extra['tile_id']) |
+                (fe.event.extra['tile_id'] != 'youtube')
+            )
+        ]),
+        all_([
+            fe.event.category == 'action',
+            fe.event.method == 'type_url',
+            fe.event.object == 'search_bar',
+        ]),
+        all_([
+            fe.event.category == 'action',
+            fe.event.method == 'type_query',
+            fe.event.object == 'search_bar',
+        ])
+    ]).astype('int')),
+
+
+@Metric.from_func(firetv_events)
+def browser_backs(fe):
+    return F.sum(all_([
+        fe.event.category == 'action',
+        fe.event.method == 'click',
+        fe.event.object == 'menu',
+        fe.event.value == 'back'
+    ]).astype('int')),
+
+
+@Metric.from_func(firetv_events)
+def remote_backs(fe):
+    return F.sum(all_([
+        fe.event.category == 'action',
+        fe.event.method == 'page',
+        fe.event.object == 'browser',
+        fe.event.value == 'back'
+    ]).astype('int')),
+
+
+@Metric.from_func(firetv_events)
+def tracking_protection_toggle_on(fe):
+    return F.sum(all_([
+        fe.event.category == 'action',
+        fe.event.method == 'change',
+        fe.event.object == 'turbo_mode',
+        fe.event.value == 'on'
+    ]).astype('int')),
+
+
+@Metric.from_func(firetv_events)
+def tracking_protection_toggle_off(fe):
+    return F.sum(all_([
+        fe.event.category == 'action',
+        fe.event.method == 'change',
+        fe.event.object == 'turbo_mode',
+        fe.event.value == 'off'
+    ]).astype('int')),
+
+
+@Metric.from_func(firetv_events)
+def tracking_protection_toggle(fe):
+    return F.sum(all_([
+        fe.event.category == 'action',
+        fe.event.method == 'change',
+        fe.event.object == 'turbo_mode',
+    ]).astype('int')),

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -719,7 +719,6 @@ def test_get_results_for_one_data_source(spark):
         3,
     )
 
-    # FIXME: update fixtures so this is unnecessary?
     enrollments = exp._add_analysis_windows_to_enrollments(enrollments, time_limits)
 
     res = exp._get_results_for_one_data_source(
@@ -728,7 +727,6 @@ def test_get_results_for_one_data_source(spark):
         [
             F.coalesce(F.sum(data_source.some_value), F.lit(0)).alias('some_value'),
         ],
-        time_limits
     )
 
     # Check that the dataframe has the correct number of rows
@@ -760,7 +758,6 @@ def test_get_results_for_one_data_source(spark):
         [
             F.coalesce(F.sum(data_source.some_value), F.lit(0)).alias('some_value'),
         ],
-        time_limits
     )
 
     assert res2.count() == enrollments.count()
@@ -804,7 +801,6 @@ def test_no_analysis_exception_when_shared_parent_dataframe(spark):
         [
             F.max(F.col('some_value'))
         ],
-        time_limits
     )
 
 

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -852,8 +852,12 @@ def test_process_metrics(spark):
     assert len(data_sources_and_metrics[ds_df_A]) == 2
     assert len(data_sources_and_metrics[ds_df_B]) == 1
 
-    assert repr(data_sources_and_metrics[ds_df_B][0]) == \
-        "Column<b'numeric_col AS `m3`'>"
+    assert 'numeric_col' in repr(data_sources_and_metrics[ds_df_B][0])
+    assert '`m3`' in repr(data_sources_and_metrics[ds_df_B][0])
+    assert repr(data_sources_and_metrics[ds_df_B][0]) in {
+        "Column<b'numeric_col AS `m3`'>",  # py3
+        "Column<numeric_col AS `m3`>",  # py2
+    }
 
 
 def test_process_metrics_dupe_data_source(spark):

--- a/tests/test_metric_libraries.py
+++ b/tests/test_metric_libraries.py
@@ -1,0 +1,7 @@
+import mozanalysis.metrics.desktop as mmd
+import mozanalysis.metrics.firetv as mmfftv
+
+
+def test_imported_ok():
+    assert mmd.active_hours
+    assert mmfftv.home_tile_clicks

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,128 @@
+import mozanalysis.metrics as mm
+
+from pyspark.sql import Column
+
+
+def test_agg_sum(spark):
+    df = register_fixture(spark)
+
+    res = df.groupBy('client_id').agg(
+        mm.agg_sum(df.numeric_col).alias('metric_value')
+    ).toPandas().set_index('client_id').metric_value
+
+    assert res['aaaa'] == 2
+    assert res['bb'] == 0
+    assert res['ccc'] == 5
+    assert res['dd'] == 0
+
+
+def test_agg_any(spark):
+    df = register_fixture(spark)
+
+    res = df.groupBy('client_id').agg(
+        mm.agg_any(df.bool_col).alias('metric_value')
+    ).toPandas().set_index('client_id').metric_value
+
+    assert res['aaaa'] == 1
+    assert res['bb'] == 0
+    assert res['ccc'] == 1
+    assert res['dd'] == 0
+
+
+def register_fixture(spark, name='simple_fixture'):
+    """Register a clients_daily fixture as a table"""
+    df = spark.createDataFrame(
+        [
+            ('aaaa', 1, True),
+            ('aaaa', 1, True),
+            ('aaaa', None, None),
+            ('aaaa', 0, False),
+            ('bb', None, None),
+            ('ccc', 5, True),
+            ('dd', 0, False),
+        ],
+        ["client_id", "numeric_col", "bool_col"]
+    )
+    df.createOrReplaceTempView(name)
+
+    return df
+
+
+def test_data_source_from_table(spark):
+    name = 'name_to_care_about'
+    orig_df = register_fixture(spark, name)
+
+    ds = mm.DataSource.from_table_name(name)
+
+    assert ds.name == name
+    ds_df = ds.get_dataframe(spark, None)
+    assert (ds_df.toPandas().fillna(0) == orig_df.toPandas().fillna(0)).all().all()
+
+
+def test_data_source_from_func(spark):
+    @mm.DataSource.from_func()
+    def ds(spark, experiment):
+        return register_fixture(spark)
+
+    assert isinstance(ds, mm.DataSource)
+
+    assert ds.name == 'ds'
+    assert ds.get_dataframe(spark, None).count() > 0
+
+
+def test_data_source_from_dataframe(spark):
+    name = 'bob'
+
+    orig_df = register_fixture(spark)
+
+    ds = mm.DataSource.from_dataframe(name, orig_df)
+
+    assert ds.name == 'bob'
+
+    ds_df = ds.get_dataframe(spark, None)
+    assert orig_df == ds_df  # Same spark object
+
+
+def data_source_fixture(spark, name='a_data_source'):
+    return mm.DataSource.from_dataframe(
+        name,
+        register_fixture(spark)
+    )
+
+
+def test_metric_from_func(spark):
+    ds = data_source_fixture(spark)
+
+    @mm.Metric.from_func(ds)
+    def a_lovely_metric(df):
+        """Hi there!"""
+        return mm.agg_sum(df.numeric_col)
+
+    assert isinstance(a_lovely_metric, mm.Metric)
+    assert a_lovely_metric.name == 'a_lovely_metric'
+    assert a_lovely_metric.data_source == ds
+    assert isinstance(a_lovely_metric.get_col(spark, None), Column)
+    assert a_lovely_metric.description == 'Hi there!'
+
+
+def test_metric_from_col(spark):
+    orig_df = register_fixture(spark)
+
+    metric = mm.Metric.from_col(
+        'a_special_metric',
+        mm.agg_sum(orig_df.numeric_col),
+        'an_ordinary_data_source',
+        orig_df
+    )
+
+    assert metric.name == 'a_special_metric'
+    assert metric.data_source.get_dataframe(spark, None) == orig_df
+
+    res = orig_df.groupBy('client_id').agg(
+        metric.get_col(spark, None)
+    ).toPandas().set_index('client_id').a_special_metric
+
+    assert res['aaaa'] == 2
+    assert res['bb'] == 0
+    assert res['ccc'] == 5
+    assert res['dd'] == 0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -108,11 +108,12 @@ def test_metric_from_func(spark):
 def test_metric_from_col(spark):
     orig_df = register_fixture(spark)
 
+    ds = mm.DataSource.from_dataframe('an_ordinary_data_source', orig_df)
+
     metric = mm.Metric.from_col(
         'a_special_metric',
         mm.agg_sum(orig_df.numeric_col),
-        'an_ordinary_data_source',
-        orig_df
+        ds
     )
 
     assert metric.name == 'a_special_metric'

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -30,7 +30,7 @@ def test_agg_any(spark):
 
 
 def register_fixture(spark, name='simple_fixture'):
-    """Register a clients_daily fixture as a table"""
+    """Register a data source fixture as a table"""
     df = spark.createDataFrame(
         [
             ('aaaa', 1, True),


### PR DESCRIPTION
Warning: this makes a breaking change to the main user-facing functions, and redefines `metric_list`.

Rather than supplying both `data_source: DataFrame` and `metric_list: iterable[Column]` to `Experiment.get_per_client_data()`, `Experiment.get_time_series_data()` and `Experiment.get_time_series_data_lazy()`, now you supply `metric_list: iterable[Metric]` - where `Metric` is a new type that represents a... metric.

In the medium-long term, on most experiments, most `Metric`s will be imported from the metrics library (e.g. `mozanalysis.metrics.desktop` for desktop experiments). The metrics library will be the canonical definition of the various metrics.

It's also fairly easy to define one-off `Metric`s for an experiment. If there's any likelihood of reuse, people should be encouraged to add their metrics to the metrics library.