### PR TITLE
Additional experiment metrics

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -269,4 +269,4 @@ Each stats technique has a module in :mod:`mozanalysis.bayesian_stats` or :mod:`
 
     mafsboot.compare_branches(gpcd_res, 'active_hours', threshold_quantile=0.9999)
 
-    sf_search_week_2 = mabssf.compare_branches(gpcd_res, 'search_count')
+    sf_search_week_2 = mabssf.compare_branches(sc, gpcd_res, 'search_count')

--- a/src/mozanalysis/metrics/__init__.py
+++ b/src/mozanalysis/metrics/__init__.py
@@ -242,10 +242,9 @@ class Metric(object):
             cd = spark.table('clients_daily')
 
             active_hours = Metric.from_col(
-                name='active_hours',
+                metric_name='active_hours',
                 col=agg_sum(cd.active_hours_sum),
-                df_name='cd',
-                df=cd,
+                data_source=cd,
             )
     """
     name = attr.ib(type=str)
@@ -299,9 +298,9 @@ class Metric(object):
             cd_ds = DataSource.from_table_name('clients_daily')
 
             active_hours = Metric.from_col(
-                name='active_hours',
+                metric_name='active_hours',
                 col=agg_sum(cd.active_hours_sum),
-                data_source=cd_ds
+                data_source=cd,
             )
         """
         return cls(

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -103,7 +103,7 @@ def fx_page_load_ms_2_mean(ms):
 
 @Metric.from_func(main_summary)
 def fx_tab_switch_total_e10s_ms_mean(ms):
-    return pings_histogram_mean(F.collect_list(ms.fx_tab_switch_total_e10s_ms_mean))
+    return pings_histogram_mean(F.collect_list(ms.histogram_parent_fx_tab_switch_total_e10s_ms))
 
 
 @Metric.from_func(main_summary)

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -2,11 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# from pyspark.sql import functions as F
+from pyspark.sql import functions as F
 
 from mozanalysis.metrics import Metric, DataSource, agg_sum, agg_any
 from mozanalysis.utils import all_  # , any_
-
+from mozanalysis.udf import pings_histogram_mean
 
 clients_daily = DataSource.from_table_name('clients_daily')
 main_summary = DataSource.from_table_name('main_summary')
@@ -94,3 +94,23 @@ def view_about_protections(events):
         events.event_object == 'protection_report',
         events.event_method == 'show',
     ]))
+
+
+@Metric.from_func(main_summary)
+def fx_page_load_ms_2_mean(ms):
+    return pings_histogram_mean(F.collect_list(ms.histogram_parent_fx_page_load_ms_2))
+
+
+@Metric.from_func(main_summary)
+def fx_tab_switch_total_e10s_ms_mean(ms):
+    return pings_histogram_mean(F.collect_list(ms.fx_tab_switch_total_e10s_ms_mean))
+
+
+@Metric.from_func(main_summary)
+def about_home_topsites_first_paint(ms):
+    return agg_sum(ms.scalar_parent_timestamps_about_home_topsites_first_paint)
+
+
+@Metric.from_func(main_summary)
+def first_paint(ms):
+    return agg_sum(ms.first_paint)

--- a/src/mozanalysis/metrics/fenix.py
+++ b/src/mozanalysis/metrics/fenix.py
@@ -18,6 +18,8 @@ def fenix_baseline(spark, experiment):
         'b_dur', bs.metrics.timespan['glean.baseline.duration']
     ).withColumn(
         'duration', F.col('b_dur.value')
+    ).withColumn(
+        'first_run_date', bs.client_info.first_run_date
     ).drop('b_dur')
 
 

--- a/src/mozanalysis/metrics/fenix.py
+++ b/src/mozanalysis/metrics/fenix.py
@@ -43,7 +43,7 @@ def fenix_events(spark, experiment):
     ).drop('event', 'extra')
 
 
-@Metric.from_func(fenix_metrics)
+@Metric.from_func(fenix_baseline)
 def uri_count(met):
     return agg_sum(met.metrics.counter['events.total_uri_count'])
 
@@ -53,17 +53,26 @@ def duration(bs):
     return agg_sum(bs.duration)
 
 
-@Metric.from_func(fenix_events)
-def user_reports_site_issue(ev):
-    return F.sum(all_([
-        ev.name == 'browser_menu_action',
-        ev.key == 'item',
-        ev.value == 'report_site_issue'
-    ]).astype('int'))
-
-
 @Metric.from_func(fenix_metrics)
 def search_count(met):
     return agg_sum(
         extract_search_counts(met.metrics.labeled_counter['metrics.search_count'])
     )
+
+
+def calc_num_events(ev, name, key, value):
+    return F.sum(all_([
+        ev.name == name,
+        ev.key == key,
+        ev.value == value
+    ]).astype('int'))
+
+
+@Metric.from_func(fenix_events)
+def user_reports_site_issue_count(ev):
+    return calc_num_events(ev, 'browser_menu_action', 'item', 'report_site_issue')
+
+
+@Metric.from_func(fenix_events)
+def user_reload_count(ev):
+    return calc_num_events(ev, 'browser_menu_action', 'item', 'reload')

--- a/src/mozanalysis/metrics/fenix.py
+++ b/src/mozanalysis/metrics/fenix.py
@@ -76,3 +76,18 @@ def user_reports_site_issue_count(ev):
 @Metric.from_func(fenix_events)
 def user_reload_count(ev):
     return calc_num_events(ev, 'browser_menu_action', 'item', 'reload')
+
+
+@Metric.from_func(fenix_baseline)
+def baseline_ping_count(bs):
+    return F.count(bs.metrics)
+
+
+@Metric.from_func(fenix_metrics)
+def metric_ping_count(met):
+    return F.count(met.metrics)
+
+
+@Metric.from_func(fenix_baseline)
+def first_run_date(bs):
+    return F.min(bs.first_run_date)

--- a/src/mozanalysis/metrics/fenix.py
+++ b/src/mozanalysis/metrics/fenix.py
@@ -3,10 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from pyspark.sql import functions as F
-from pyspark.sql import types as T
 
 from mozanalysis.metrics import Metric, DataSource, agg_sum
 from mozanalysis.utils import all_
+from mozanalysis.udf import extract_search_counts
 
 
 @DataSource.from_func()
@@ -60,14 +60,6 @@ def user_reports_site_issue(ev):
         ev.key == 'item',
         ev.value == 'report_site_issue'
     ]).astype('int'))
-
-
-@F.udf(returnType=T.IntegerType())
-def extract_search_counts(x):
-    counts = 0
-    if x is not None:
-        counts = sum(x.values())
-    return counts
 
 
 @Metric.from_func(fenix_metrics)

--- a/src/mozanalysis/metrics/fenix.py
+++ b/src/mozanalysis/metrics/fenix.py
@@ -1,0 +1,77 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from pyspark.sql import functions as F
+from pyspark.sql import types as T
+
+from mozanalysis.metrics import Metric, DataSource
+from mozanalysis.utils import all_
+
+
+@DataSource.from_func()
+def fenix_baseline(spark, experiment):
+    bs = spark.table('org_mozilla_fenix_baseline_parquet')
+    return bs.withColumn(
+        'client_id', bs.client_info.client_id
+    ).withColumn(
+        'b_dur', bs.metrics.timespan['glean.baseline.duration']
+    ).withColumn(
+        'duration', F.col('b_dur.value')
+    ).drop('b_dur')
+
+
+@DataSource.from_func()
+def fenix_metrics(spark, experiment):
+    met = spark.table('org_mozilla_fenix_metrics_parquet')
+    return met.m.withColumn('client_id', met.client_info.client_id)
+
+
+@DataSource.from_func()
+def fenix_events(spark, experiment):
+    ev = spark.table('org_mozilla_fenix_events_parquet')
+    return ev.select(
+        ev.client_info.client_id.alias('client_id'),
+        ev.submission_date_s3,
+        F.explode_outer(e.events).alias('event')
+    ).select(
+        'event.*',
+        '*'
+    ).select(
+        '*',
+        F.explode_outer(F.col('extra'))
+    ).drop('event', 'extra')
+
+
+@Metric.from_func(fenix_metrics)
+def uri_count(met):
+    return met.agg_sum(met.metrics.counter['events.total_uri_count'])
+
+
+@Metric.from_func(fenix_baseline)
+def duration(bs):
+    return bs.agg_sum(bs.duration)
+
+
+@Metric.from_func(fenix_events)
+def user_reports_site_issue(ev):
+    return F.sum(all_([
+        ev.name == 'browser_menu_action',
+        ev.key == 'item',
+        ev.value == 'report_site_issue'
+    ]).astype('int'))
+
+
+@F.udf(returnType=T.IntegerType())
+def extract_search_counts(x):
+    counts = 0
+    if x is not None:
+        counts = sum(x.values())
+    return counts
+
+
+@Metric.from_func(fenix_metrics)
+def search_count(met):
+    return met.agg_sum(
+        extract_search_counts(met.metrics.labeled_counter['metrics.search_count'])
+    )

--- a/src/mozanalysis/udf.py
+++ b/src/mozanalysis/udf.py
@@ -215,10 +215,14 @@ def generate_threshold_udf(sdf, grouping_fields, bucket_field, count_field, thre
 
 @F.udf(DoubleType())
 def pings_histogram_mean(hists):
-    """Returns the mean of values in a histogram.
-    This mean relies on the sum *post*-quantization, which amounts to a
-    left-hand-rule discrete integral of the histogram. It is therefore
-    likely to be an underestimate of the true mean.
+    """ Returns the mean of a list of histograms
+
+    Args:
+        hists: list of dict
+
+    Returns:
+        mean: float
+
     """
     numerator = 0
     denominator = 0
@@ -240,3 +244,13 @@ def extract_search_counts(x):
     if x is not None:
         counts = sum(x.values())
     return counts
+
+
+@F.udf(returnType=DoubleType())
+def mean_narm(x):
+    values = [float(value) for value in x if x is not None]
+    if values:
+        avg = sum(values) / len(values)
+    else:
+        avg = None
+    return avg

--- a/tests/test_metric_libraries.py
+++ b/tests/test_metric_libraries.py
@@ -1,7 +1,9 @@
 import mozanalysis.metrics.desktop as mmd
 import mozanalysis.metrics.firetv as mmfftv
+import mozanalysis.metrics.fenix as mmf
 
 
 def test_imported_ok():
     assert mmd.active_hours
     assert mmfftv.home_tile_clicks
+    assert mmf.duration


### PR DESCRIPTION
Added additional performance metrics to `metrics.desktop`:
* `fx_page_load_ms_2_mean`
* `fx_tab_switch_total_e10s_ms_mean`
* `about_home_topsites_first_paint`
* `first_paint`

The first two required the addition of a UDF in `utils.udf` to aggregate the histograms. 

In addition, created a `metrics.fenix` package. 