### PR TITLE
 Make bootstrapping work without Spark.

### DIFF
--- a/src/mozanalysis/bayesian_stats/bayesian_bootstrap.py
+++ b/src/mozanalysis/bayesian_stats/bayesian_bootstrap.py
@@ -97,15 +97,15 @@ def make_bb_quantile_closure(quantiles):
 
 
 def compare_branches(
-    sc, df, col_label, ref_branch_label='control', stat_fn=bb_mean,
+    df, col_label, ref_branch_label='control', stat_fn=bb_mean,
     num_samples=10000, threshold_quantile=None,
     individual_summary_quantiles=mabs.DEFAULT_QUANTILES,
-    comparative_summary_quantiles=mabs.DEFAULT_QUANTILES
+    comparative_summary_quantiles=mabs.DEFAULT_QUANTILES,
+    sc=None
 ):
     """Jointly sample bootstrapped statistics then compare them.
 
     Args:
-        sc: The Spark context
         df: a pandas DataFrame of queried experiment data in the
             standard format (see `mozanalysis.experiment`).
         col_label (str): Label for the df column contaning the metric
@@ -139,6 +139,7 @@ def compare_branches(
             statistics (i.e. the change relative to the reference
             branch, probably the control). Change these when making
             Bonferroni corrections.
+        sc (optional): The Spark context, if available
 
     Returns:
         If ``stat_fn`` returns a scalar (this is the default), then
@@ -168,11 +169,11 @@ def compare_branches(
     samples = {
         # TODO: do we need to control seed_start? If so then we must be careful here
         b: get_bootstrap_samples(
-            sc,
             df[col_label][df.branch == b],
             stat_fn,
             num_samples,
-            threshold_quantile=threshold_quantile
+            threshold_quantile=threshold_quantile,
+            sc=sc,
         ) for b in branch_list
     }
 
@@ -183,8 +184,9 @@ def compare_branches(
 
 
 def bootstrap_one_branch(
-    sc, data, stat_fn=bb_mean, num_samples=10000, seed_start=None,
-    threshold_quantile=None, summary_quantiles=mabs.DEFAULT_QUANTILES
+    data, stat_fn=bb_mean, num_samples=10000, seed_start=None,
+    threshold_quantile=None, summary_quantiles=mabs.DEFAULT_QUANTILES,
+    sc=None
 ):
     """Bootstrap ``stat_fn`` for one branch on its own.
 
@@ -192,7 +194,6 @@ def bootstrap_one_branch(
     then returns summary statistics for the results.
 
     Args:
-        sc: The spark context
         data: The data as a list, 1D numpy array, or pandas Series
         stat_fn (callable, optional): A function that either:
 
@@ -216,22 +217,22 @@ def bootstrap_one_branch(
         summary_quantiles (list, optional): Quantiles to determine the
             confidence bands on the branch statistics. Change these
             when making Bonferroni corrections.
+        sc (optional): The Spark context, if available
     """
     samples = get_bootstrap_samples(
-        sc, data, stat_fn, num_samples, seed_start, threshold_quantile
+        data, stat_fn, num_samples, seed_start, threshold_quantile, sc
     )
 
     return mabs.summarize_one_branch_samples(samples, summary_quantiles)
 
 
 def get_bootstrap_samples(
-    sc, data, stat_fn=bb_mean, num_samples=10000, seed_start=None,
-    threshold_quantile=None
+    data, stat_fn=bb_mean, num_samples=10000, seed_start=None,
+    threshold_quantile=None, sc=None
 ):
     """Return ``stat_fn`` evaluated on resampled data.
 
     Args:
-        sc: The spark context
         data: The data as a list, 1D numpy array, or pandas series
         stat_fn (callable, optional): A function that either:
 
@@ -258,6 +259,7 @@ def get_bootstrap_samples(
 
         threshold_quantile (float, optional): An optional threshold
             quantile, above which to discard outliers. E.g. ``0.9999``.
+        sc (optional): The Spark context, if available
 
     Returns:
         A Series or DataFrame with one row per sample and one column
@@ -289,24 +291,29 @@ def get_bootstrap_samples(
     # Need to ensure every call has a unique, deterministic seed.
     seed_range = range(seed_start, seed_start + num_samples)
 
-    # TODO: run locally `if sc is None`?
-    # TODO: maybe we can just run locally anyway? It's efficient...
-    try:
-        broadcast_data_values = sc.broadcast(data_values)
-        broadcast_data_counts = sc.broadcast(data_counts)
+    if sc is None:
+        summary_stat_samples = [
+            _resample_and_agg_once(data_values, data_counts, stat_fn, unique_seed)
+            for unique_seed in seed_range
+        ]
 
-        summary_stat_samples = sc.parallelize(seed_range).map(
-            lambda seed: _resample_and_agg_once_bcast(
-                broadcast_data_values=broadcast_data_values,
-                broadcast_data_counts=broadcast_data_counts,
-                stat_fn=stat_fn,
-                unique_seed=seed % np.iinfo(np.uint32).max,
-            )
-        ).collect()
+    else:
+        try:
+            broadcast_data_values = sc.broadcast(data_values)
+            broadcast_data_counts = sc.broadcast(data_counts)
 
-    finally:
-        broadcast_data_values.unpersist()
-        broadcast_data_counts.unpersist()
+            summary_stat_samples = sc.parallelize(seed_range).map(
+                lambda seed: _resample_and_agg_once_bcast(
+                    broadcast_data_values=broadcast_data_values,
+                    broadcast_data_counts=broadcast_data_counts,
+                    stat_fn=stat_fn,
+                    unique_seed=seed % np.iinfo(np.uint32).max,
+                )
+            ).collect()
+
+        finally:
+            broadcast_data_values.unpersist()
+            broadcast_data_counts.unpersist()
 
     summary_df = pd.DataFrame(summary_stat_samples)
     if len(summary_df.columns) == 1:

--- a/tests/bayesian_stats/test_bayesian_bootstrap.py
+++ b/tests/bayesian_stats/test_bayesian_bootstrap.py
@@ -137,7 +137,7 @@ def test_bootstrap_one_branch_multistat_no_spark():
     test_bootstrap_one_branch_multistat(None)
 
 
-def test_compare_branches(spark_context):
+def test_compare_branches(spark_context_or_none):
     data = pd.DataFrame(
         index=range(60000),
         columns=['branch', 'val'],
@@ -155,7 +155,7 @@ def test_compare_branches(spark_context):
     assert data.val[data.branch != 'bigger'].mean() == 0.5
     assert data.val[data.branch == 'bigger'].mean() == pytest.approx(0.75)
 
-    res = mabsbb.compare_branches(data, 'val', num_samples=2, sc=spark_context)
+    res = mabsbb.compare_branches(data, 'val', num_samples=2, sc=spark_context_or_none)
 
     assert res['individual']['control']['mean'] == pytest.approx(0.5, rel=1e-1)
     assert res['individual']['same']['mean'] == pytest.approx(0.5, rel=1e-1)
@@ -173,11 +173,7 @@ def test_compare_branches(spark_context):
         pytest.approx(1, abs=0.01)
 
 
-def test_compare_branches_no_spark():
-    test_compare_branches(None)
-
-
-def test_compare_branches_multistat(spark_context):
+def test_compare_branches_multistat(spark_context_or_none):
     data = pd.DataFrame(
         index=range(60000),
         columns=['branch', 'val'],
@@ -203,7 +199,7 @@ def test_compare_branches_multistat(spark_context):
             'mean': np.dot(x, y),
         },
         num_samples=2,
-        sc=spark_context,
+        sc=spark_context_or_none,
     )
 
     assert res['individual']['control'].loc['mean', 'mean'] \
@@ -227,10 +223,6 @@ def test_compare_branches_multistat(spark_context):
 
     assert res['comparative']['same'].loc['max', ('rel_uplift', 'exp')] == 0
     assert res['comparative']['bigger'].loc['max', ('rel_uplift', 'exp')] == 0
-
-
-def test_compare_branches_multistat_no_spark():
-    test_compare_branches_multistat(None)
 
 
 def test_bb_mean():

--- a/tests/bayesian_stats/test_bayesian_bootstrap.py
+++ b/tests/bayesian_stats/test_bayesian_bootstrap.py
@@ -49,24 +49,28 @@ def test_resample_and_agg_once_bcast(spark_context):
 
 def test_get_bootstrap_samples(spark_context):
     res = mabsbb.get_bootstrap_samples(
-        spark_context, np.array([3., 3., 3.]), num_samples=2
+        np.array([3., 3., 3.]), num_samples=2, sc=spark_context
     )
     assert res.shape == (2,)
     assert res[0] == pytest.approx(3.)
     assert res[1] == pytest.approx(3.)
 
 
+def test_get_bootstrap_samples_no_spark():
+    test_get_bootstrap_samples(None)
+
+
 def test_get_bootstrap_samples_multistat(spark_context, stack_depth=0):
     data = np.concatenate([np.zeros(10000), np.ones(10000)])
     res = mabsbb.get_bootstrap_samples(
-        spark_context,
         data,
         lambda x, y: {
             'min': np.min(x),
             'max': np.max(x),
             'mean': np.dot(x, y),
         },
-        num_samples=2
+        num_samples=2,
+        sc=spark_context
     )
 
     assert res.shape == (2, 3)
@@ -86,10 +90,14 @@ def test_get_bootstrap_samples_multistat(spark_context, stack_depth=0):
         test_get_bootstrap_samples_multistat(spark_context, stack_depth + 1)
 
 
+def test_get_bootstrap_samples_multistat_no_spark():
+    test_get_bootstrap_samples_multistat(None)
+
+
 def test_bootstrap_one_branch(spark_context):
     data = np.concatenate([np.zeros(10000), np.ones(10000)])
     res = mabsbb.bootstrap_one_branch(
-        spark_context, data, num_samples=100, summary_quantiles=(0.5, 0.61)
+        data, num_samples=100, summary_quantiles=(0.5, 0.61), sc=spark_context
     )
 
     assert res['mean'] == pytest.approx(0.5, rel=1e-1)
@@ -97,17 +105,22 @@ def test_bootstrap_one_branch(spark_context):
     assert res['0.61'] == pytest.approx(0.5, rel=1e-1)
 
 
+def test_bootstrap_one_branch_no_spark():
+    test_bootstrap_one_branch(None)
+
+
 def test_bootstrap_one_branch_multistat(spark_context):
     data = np.concatenate([np.zeros(10000), np.ones(10000), [1e20]])
     res = mabsbb.bootstrap_one_branch(
-        spark_context, data,
+        data,
         stat_fn=lambda x, y: {
             'max': np.max(x),
             'mean': np.dot(x, y),
         },
         num_samples=5,
         summary_quantiles=(0.5, 0.61),
-        threshold_quantile=0.9999
+        threshold_quantile=0.9999,
+        sc=spark_context,
     )
 
     assert res.shape == (2, 3)
@@ -118,6 +131,10 @@ def test_bootstrap_one_branch_multistat(spark_context):
     assert res.loc['mean', 'mean'] == pytest.approx(0.5, rel=1e-1)
     assert res.loc['mean', '0.5'] == pytest.approx(0.5, rel=1e-1)
     assert res.loc['mean', '0.61'] == pytest.approx(0.5, rel=1e-1)
+
+
+def test_bootstrap_one_branch_multistat_no_spark():
+    test_bootstrap_one_branch_multistat(None)
 
 
 def test_compare_branches(spark_context):
@@ -138,7 +155,7 @@ def test_compare_branches(spark_context):
     assert data.val[data.branch != 'bigger'].mean() == 0.5
     assert data.val[data.branch == 'bigger'].mean() == pytest.approx(0.75)
 
-    res = mabsbb.compare_branches(spark_context, data, 'val', num_samples=2)
+    res = mabsbb.compare_branches(data, 'val', num_samples=2, sc=spark_context)
 
     assert res['individual']['control']['mean'] == pytest.approx(0.5, rel=1e-1)
     assert res['individual']['same']['mean'] == pytest.approx(0.5, rel=1e-1)
@@ -154,6 +171,10 @@ def test_compare_branches(spark_context):
     assert res['comparative']['same'][('prob_win', None)] in (0, 0.5, 1)
     assert res['comparative']['bigger'][('prob_win', None)] == \
         pytest.approx(1, abs=0.01)
+
+
+def test_compare_branches_no_spark():
+    test_compare_branches(None)
 
 
 def test_compare_branches_multistat(spark_context):
@@ -175,14 +196,14 @@ def test_compare_branches_multistat(spark_context):
     assert data.val[data.branch == 'bigger'].mean() == pytest.approx(0.75)
 
     res = mabsbb.compare_branches(
-        spark_context,
         data,
         'val',
         stat_fn=lambda x, y: {
             'max': np.max(x),
             'mean': np.dot(x, y),
         },
-        num_samples=2
+        num_samples=2,
+        sc=spark_context,
     )
 
     assert res['individual']['control'].loc['mean', 'mean'] \
@@ -206,6 +227,10 @@ def test_compare_branches_multistat(spark_context):
 
     assert res['comparative']['same'].loc['max', ('rel_uplift', 'exp')] == 0
     assert res['comparative']['bigger'].loc['max', ('rel_uplift', 'exp')] == 0
+
+
+def test_compare_branches_multistat_no_spark():
+    test_compare_branches_multistat(None)
 
 
 def test_bb_mean():

--- a/tests/bayesian_stats/test_consistency.py
+++ b/tests/bayesian_stats/test_consistency.py
@@ -15,7 +15,7 @@ def test_bootstrap_vs_beta(spark_context):
     fake_data = pd.Series(np.zeros(num_enrollments))
     fake_data[:300] = 1
 
-    boot_res = mafsb.bootstrap_one_branch(spark_context, fake_data)
+    boot_res = mafsb.bootstrap_one_branch(fake_data, sc=spark_context)
     beta_res = mabsbin.summarize_one_branch_from_agg(pd.Series({
         # `-1` to simulate Beta(0, 0) improper prior, closer to
         # bootstrap for quantiles (i think?)
@@ -40,6 +40,10 @@ def test_bootstrap_vs_beta(spark_context):
         ), l
 
 
+def test_bootstrap_vs_beta_no_spark():
+    test_bootstrap_vs_beta(None)
+
+
 def test_bayesian_bootstrap_vs_beta(spark_context):
     # The two distributions should be mathematically identical for binary data
     # like this; differences could emerge from
@@ -49,7 +53,7 @@ def test_bayesian_bootstrap_vs_beta(spark_context):
     fake_data = pd.Series(np.zeros(num_enrollments))
     fake_data[:300] = 1
 
-    boot_res = mabsbb.bootstrap_one_branch(spark_context, fake_data)
+    boot_res = mabsbb.bootstrap_one_branch(fake_data, sc=spark_context)
     beta_res = mabsbin.summarize_one_branch_from_agg(pd.Series({
         # `-1` to simulate Beta(0, 0) improper prior, closer to
         # bootstrap for quantiles (i think?)
@@ -66,14 +70,18 @@ def test_bayesian_bootstrap_vs_beta(spark_context):
         ), (l, boot_res, beta_res)
 
 
+def test_bayesian_bootstrap_vs_beta_no_spark():
+    test_bayesian_bootstrap_vs_beta(None)
+
+
 def test_bayesian_bootstrap_vs_bootstrap_geometric(spark_context):
     num_enrollments = 20000
 
     rs = np.random.RandomState(42)
     data = rs.geometric(p=0.1, size=num_enrollments)
 
-    bb_res = mabsbb.bootstrap_one_branch(spark_context, data)
-    pboot_res = mafsb.bootstrap_one_branch(spark_context, data)
+    bb_res = mabsbb.bootstrap_one_branch(data, sc=spark_context)
+    pboot_res = mafsb.bootstrap_one_branch(data, sc=spark_context)
 
     assert bb_res['mean'] == pytest.approx(10, rel=1e-2)
     assert bb_res['0.5'] == pytest.approx(10, rel=1e-2)
@@ -83,6 +91,10 @@ def test_bayesian_bootstrap_vs_bootstrap_geometric(spark_context):
             pboot_res.loc[l],
             rel=5e-3
         ), (l, bb_res, pboot_res)
+
+
+def test_bayesian_bootstrap_vs_bootstrap_geometric_no_spark():
+    test_bayesian_bootstrap_vs_bootstrap_geometric(None)
 
 
 def test_bayesian_bootstrap_vs_bootstrap_geometric_quantiles(spark_context):
@@ -99,10 +111,13 @@ def test_bayesian_bootstrap_vs_bootstrap_geometric_quantiles(spark_context):
         ))
 
     bb_res = mabsbb.bootstrap_one_branch(
-        spark_context, data,
-        stat_fn=mabsbb.make_bb_quantile_closure(quantiles)
+        data,
+        stat_fn=mabsbb.make_bb_quantile_closure(quantiles),
+        sc=spark_context
     )
-    pboot_res = mafsb.bootstrap_one_branch(spark_context, data, stat_fn=calc_quantiles)
+    pboot_res = mafsb.bootstrap_one_branch(
+        data, stat_fn=calc_quantiles, sc=spark_context
+    )
 
     for q in bb_res.index:
         for l in bb_res.columns:
@@ -112,14 +127,18 @@ def test_bayesian_bootstrap_vs_bootstrap_geometric_quantiles(spark_context):
             ), (q, l, bb_res, pboot_res)
 
 
+def test_bayesian_bootstrap_vs_bootstrap_geometric_quantiles_no_spark():
+    test_bayesian_bootstrap_vs_bootstrap_geometric_quantiles(None)
+
+
 def test_bayesian_bootstrap_vs_bootstrap_poisson(spark_context):
     num_enrollments = 10001
 
     rs = np.random.RandomState(42)
     data = rs.poisson(lam=10, size=num_enrollments)
 
-    bb_res = mabsbb.bootstrap_one_branch(spark_context, data)
-    pboot_res = mafsb.bootstrap_one_branch(spark_context, data)
+    bb_res = mabsbb.bootstrap_one_branch(data, sc=spark_context)
+    pboot_res = mafsb.bootstrap_one_branch(data, sc=spark_context)
 
     assert bb_res['mean'] == pytest.approx(10, rel=1e-2)
     assert bb_res['0.5'] == pytest.approx(10, rel=1e-2)
@@ -129,6 +148,10 @@ def test_bayesian_bootstrap_vs_bootstrap_poisson(spark_context):
             pboot_res.loc[l],
             rel=5e-3
         ), (l, bb_res, pboot_res)
+
+
+def test_bayesian_bootstrap_vs_bootstrap_poisson_no_spark():
+    test_bayesian_bootstrap_vs_bootstrap_poisson(None)
 
 
 def test_bayesian_bootstrap_vs_bootstrap_poisson_quantiles(spark_context):
@@ -145,10 +168,13 @@ def test_bayesian_bootstrap_vs_bootstrap_poisson_quantiles(spark_context):
         ))
 
     bb_res = mabsbb.bootstrap_one_branch(
-        spark_context, data,
-        stat_fn=mabsbb.make_bb_quantile_closure(quantiles)
+        data,
+        stat_fn=mabsbb.make_bb_quantile_closure(quantiles),
+        sc=spark_context
     )
-    pboot_res = mafsb.bootstrap_one_branch(spark_context, data, stat_fn=calc_quantiles)
+    pboot_res = mafsb.bootstrap_one_branch(
+        data, stat_fn=calc_quantiles, sc=spark_context
+    )
 
     for q in bb_res.index:
         for l in bb_res.columns:
@@ -156,3 +182,7 @@ def test_bayesian_bootstrap_vs_bootstrap_poisson_quantiles(spark_context):
                 pboot_res.loc[q, l],
                 rel=5e-3
             ), (q, l, bb_res, pboot_res)
+
+
+def test_bayesian_bootstrap_vs_bootstrap_poisson_quantiles_no_spark():
+    test_bayesian_bootstrap_vs_bootstrap_poisson_quantiles(None)

--- a/tests/bayesian_stats/test_consistency.py
+++ b/tests/bayesian_stats/test_consistency.py
@@ -10,12 +10,12 @@ import mozanalysis.bayesian_stats.bayesian_bootstrap as mabsbb
 import mozanalysis.frequentist_stats.bootstrap as mafsb
 
 
-def test_bootstrap_vs_beta(spark_context):
+def test_bootstrap_vs_beta(spark_context_or_none):
     num_enrollments = 10000
     fake_data = pd.Series(np.zeros(num_enrollments))
     fake_data[:300] = 1
 
-    boot_res = mafsb.bootstrap_one_branch(fake_data, sc=spark_context)
+    boot_res = mafsb.bootstrap_one_branch(fake_data, sc=spark_context_or_none)
     beta_res = mabsbin.summarize_one_branch_from_agg(pd.Series({
         # `-1` to simulate Beta(0, 0) improper prior, closer to
         # bootstrap for quantiles (i think?)
@@ -40,11 +40,7 @@ def test_bootstrap_vs_beta(spark_context):
         ), l
 
 
-def test_bootstrap_vs_beta_no_spark():
-    test_bootstrap_vs_beta(None)
-
-
-def test_bayesian_bootstrap_vs_beta(spark_context):
+def test_bayesian_bootstrap_vs_beta(spark_context_or_none):
     # The two distributions should be mathematically identical for binary data
     # like this; differences could emerge from
     # 1. implementation errors
@@ -53,7 +49,7 @@ def test_bayesian_bootstrap_vs_beta(spark_context):
     fake_data = pd.Series(np.zeros(num_enrollments))
     fake_data[:300] = 1
 
-    boot_res = mabsbb.bootstrap_one_branch(fake_data, sc=spark_context)
+    boot_res = mabsbb.bootstrap_one_branch(fake_data, sc=spark_context_or_none)
     beta_res = mabsbin.summarize_one_branch_from_agg(pd.Series({
         # `-1` to simulate Beta(0, 0) improper prior, closer to
         # bootstrap for quantiles (i think?)
@@ -70,18 +66,14 @@ def test_bayesian_bootstrap_vs_beta(spark_context):
         ), (l, boot_res, beta_res)
 
 
-def test_bayesian_bootstrap_vs_beta_no_spark():
-    test_bayesian_bootstrap_vs_beta(None)
-
-
-def test_bayesian_bootstrap_vs_bootstrap_geometric(spark_context):
+def test_bayesian_bootstrap_vs_bootstrap_geometric(spark_context_or_none):
     num_enrollments = 20000
 
     rs = np.random.RandomState(42)
     data = rs.geometric(p=0.1, size=num_enrollments)
 
-    bb_res = mabsbb.bootstrap_one_branch(data, sc=spark_context)
-    pboot_res = mafsb.bootstrap_one_branch(data, sc=spark_context)
+    bb_res = mabsbb.bootstrap_one_branch(data, sc=spark_context_or_none)
+    pboot_res = mafsb.bootstrap_one_branch(data, sc=spark_context_or_none)
 
     assert bb_res['mean'] == pytest.approx(10, rel=1e-2)
     assert bb_res['0.5'] == pytest.approx(10, rel=1e-2)
@@ -93,11 +85,7 @@ def test_bayesian_bootstrap_vs_bootstrap_geometric(spark_context):
         ), (l, bb_res, pboot_res)
 
 
-def test_bayesian_bootstrap_vs_bootstrap_geometric_no_spark():
-    test_bayesian_bootstrap_vs_bootstrap_geometric(None)
-
-
-def test_bayesian_bootstrap_vs_bootstrap_geometric_quantiles(spark_context):
+def test_bayesian_bootstrap_vs_bootstrap_geometric_quantiles(spark_context_or_none):
     num_enrollments = 20000
 
     rs = np.random.RandomState(42)
@@ -113,10 +101,10 @@ def test_bayesian_bootstrap_vs_bootstrap_geometric_quantiles(spark_context):
     bb_res = mabsbb.bootstrap_one_branch(
         data,
         stat_fn=mabsbb.make_bb_quantile_closure(quantiles),
-        sc=spark_context
+        sc=spark_context_or_none
     )
     pboot_res = mafsb.bootstrap_one_branch(
-        data, stat_fn=calc_quantiles, sc=spark_context
+        data, stat_fn=calc_quantiles, sc=spark_context_or_none
     )
 
     for q in bb_res.index:
@@ -127,18 +115,14 @@ def test_bayesian_bootstrap_vs_bootstrap_geometric_quantiles(spark_context):
             ), (q, l, bb_res, pboot_res)
 
 
-def test_bayesian_bootstrap_vs_bootstrap_geometric_quantiles_no_spark():
-    test_bayesian_bootstrap_vs_bootstrap_geometric_quantiles(None)
-
-
-def test_bayesian_bootstrap_vs_bootstrap_poisson(spark_context):
+def test_bayesian_bootstrap_vs_bootstrap_poisson(spark_context_or_none):
     num_enrollments = 10001
 
     rs = np.random.RandomState(42)
     data = rs.poisson(lam=10, size=num_enrollments)
 
-    bb_res = mabsbb.bootstrap_one_branch(data, sc=spark_context)
-    pboot_res = mafsb.bootstrap_one_branch(data, sc=spark_context)
+    bb_res = mabsbb.bootstrap_one_branch(data, sc=spark_context_or_none)
+    pboot_res = mafsb.bootstrap_one_branch(data, sc=spark_context_or_none)
 
     assert bb_res['mean'] == pytest.approx(10, rel=1e-2)
     assert bb_res['0.5'] == pytest.approx(10, rel=1e-2)
@@ -150,11 +134,7 @@ def test_bayesian_bootstrap_vs_bootstrap_poisson(spark_context):
         ), (l, bb_res, pboot_res)
 
 
-def test_bayesian_bootstrap_vs_bootstrap_poisson_no_spark():
-    test_bayesian_bootstrap_vs_bootstrap_poisson(None)
-
-
-def test_bayesian_bootstrap_vs_bootstrap_poisson_quantiles(spark_context):
+def test_bayesian_bootstrap_vs_bootstrap_poisson_quantiles(spark_context_or_none):
     num_enrollments = 10001
 
     rs = np.random.RandomState(42)
@@ -170,10 +150,10 @@ def test_bayesian_bootstrap_vs_bootstrap_poisson_quantiles(spark_context):
     bb_res = mabsbb.bootstrap_one_branch(
         data,
         stat_fn=mabsbb.make_bb_quantile_closure(quantiles),
-        sc=spark_context
+        sc=spark_context_or_none
     )
     pboot_res = mafsb.bootstrap_one_branch(
-        data, stat_fn=calc_quantiles, sc=spark_context
+        data, stat_fn=calc_quantiles, sc=spark_context_or_none
     )
 
     for q in bb_res.index:
@@ -182,7 +162,3 @@ def test_bayesian_bootstrap_vs_bootstrap_poisson_quantiles(spark_context):
                 pboot_res.loc[q, l],
                 rel=5e-3
             ), (q, l, bb_res, pboot_res)
-
-
-def test_bayesian_bootstrap_vs_bootstrap_poisson_quantiles_no_spark():
-    test_bayesian_bootstrap_vs_bootstrap_poisson_quantiles(None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,3 +35,20 @@ def spark():
 @pytest.fixture()
 def spark_context(spark):
     return _spark_context
+
+
+def pytest_generate_tests(metafunc):
+    if 'spark_context_or_none' in metafunc.fixturenames:
+        metafunc.parametrize(
+            "spark_context_or_none", ["spark", "no spark"], indirect=True
+        )
+
+
+@pytest.fixture()
+def spark_context_or_none(request):
+    if request.param == 'spark':
+        return _spark_context
+    elif request.param == 'no spark':
+        return None
+    else:
+        raise ValueError("invalid internal test config")


### PR DESCRIPTION
This makes a breaking change to the bootstrap function signatures: arguments are re-ordered so that `sc` becomes optional.

Mozanalysis will now be frequently run without a Spark context. We'll still need to bootstrap.

Now if no Spark context is supplied, non-parallel implementations of the bootstrap will be run.

