### PR TITLE
Add metric for connecting a firefox account

### DIFF
--- a/src/mozanalysis/metrics/__init__.py
+++ b/src/mozanalysis/metrics/__init__.py
@@ -8,7 +8,7 @@ import attr
 class DataSource(object):
     name = attr.ib(validator=attr.validators.instance_of(str))
     from_expr = attr.ib(validator=attr.validators.instance_of(str))
-    experiments_column_type = attr.ib(default='desktop_main_ping', type=str)
+    experiments_column_type = attr.ib(default='simple', type=str)
     client_id_column = attr.ib(default='client_id', type=str)
     submission_date_column = attr.ib(default='submission_date', type=str)
 
@@ -17,7 +17,7 @@ class DataSource(object):
         if self.experiments_column_type is None:
             return ''
 
-        elif self.experiments_column_type == 'desktop_main_ping':
+        elif self.experiments_column_type == 'simple':
             return """AND (
                     ds.{submission_date} != e.enrollment_date
                     OR `moz-fx-data-shared-prod.udf.get_key`(
@@ -25,7 +25,7 @@ class DataSource(object):
                     ) IS NOT NULL
                 )"""
 
-        elif self.experiments_column_type == 'map_struct':
+        elif self.experiments_column_type == 'native':
             return """AND (
                     ds.{submission_date} != e.enrollment_date
                     OR `moz-fx-data-shared-prod.udf.get_key`(
@@ -80,7 +80,7 @@ class DataSource(object):
         if self.experiments_column_type is None:
             return []
 
-        elif self.experiments_column_type == 'desktop_main_ping':
+        elif self.experiments_column_type == 'simple':
             return [
                 Metric(
                     name=self.name + '_has_contradictory_branch',
@@ -98,7 +98,7 @@ class DataSource(object):
                 ),
             ]
 
-        elif self.experiments_column_type == 'map_struct':
+        elif self.experiments_column_type == 'native':
             return [
                 Metric(
                     name=self.name + '_has_contradictory_branch',

--- a/src/mozanalysis/metrics/__init__.py
+++ b/src/mozanalysis/metrics/__init__.py
@@ -98,6 +98,24 @@ class DataSource(object):
                 ),
             ]
 
+        elif self.experiments_column_type == 'map_struct':
+            return [
+                Metric(
+                    name=self.name + '_has_contradictory_branch',
+                    data_source=self,
+                    select_expr=agg_any("""`moz-fx-data-shared-prod.udf.get_key`(
+                ds.experiments, '{experiment_slug}'
+            ).branch != e.branch"""),
+                ),
+                Metric(
+                    name=self.name + '_has_non_enrolled_data',
+                    data_source=self,
+                    select_expr=agg_any("""`moz-fx-data-shared-prod.udf.get_key`(
+                ds.experiments, '{experiment_slug}'
+            ).branch IS NULL""".format(experiment_slug=experiment_slug))
+                ),
+            ]
+
         elif self.experiments_column_type == 'glean':
             raise NotImplementedError
 

--- a/src/mozanalysis/metrics/__init__.py
+++ b/src/mozanalysis/metrics/__init__.py
@@ -25,6 +25,14 @@ class DataSource(object):
                     ) IS NOT NULL
                 )"""
 
+        elif self.experiments_column_type == 'map_struct':
+            return """AND (
+                    ds.{submission_date} != e.enrollment_date
+                    OR `moz-fx-data-shared-prod.udf.get_key`(
+                        ds.experiments, '{experiment_slug}'
+                    ).branch IS NOT NULL
+            )"""
+
         elif self.experiments_column_type == 'glean':
             raise NotImplementedError
 

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -61,35 +61,35 @@ unenroll = Metric(
     name='unenroll',
     data_source=events,
     select_expr=agg_any("""
-            event_category = 'normandy'
-            AND event_method = 'unenroll'
-            AND event_string_value = '{experiment_slug}'
-        """)
+                event_category = 'normandy'
+                AND event_method = 'unenroll'
+                AND event_string_value = '{experiment_slug}'
+            """)
 )
 
 view_about_logins = Metric(
     name='view_about_logins',
     data_source=events,
     select_expr=agg_any("""
-            event_method = 'open_management'
-            AND event_category = 'pwmgr'
-        """)
+                event_method = 'open_management'
+                AND event_category = 'pwmgr'
+            """)
 )
 
 view_about_protections = Metric(
     name='view_about_protections',
     data_source=events,
     select_expr=agg_any("""
-            event_method = 'show'
-            AND event_object = 'protection_report'
-        """)
+                event_method = 'show'
+                AND event_object = 'protection_report'
+            """)
 )
 
 connect_fxa = Metric(
     name='connect_fxa',
     data_source=events,
     select_expr=agg_any("""
-            event_method = 'connect'
-            AND event_object = 'account'
-    """)
+                event_method = 'connect'
+                AND event_object = 'account'
+            """)
 )

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -83,3 +83,12 @@ view_about_protections = Metric(
             AND event_object = 'protection_report'
         """)
 )
+
+connect_fxa = Metric(
+    name='connect_fxa',
+    data_source=events,
+    select_expr=agg_any("""
+            event_method = 'connect'
+            AND event_object = 'account'
+    """)
+)

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -23,7 +23,8 @@ main_summary = DataSource(
 
 events = DataSource(
     name='events',
-    from_expr="`moz-fx-data-shared-prod.telemetry.events`"
+    from_expr="`moz-fx-data-shared-prod.telemetry.events`",
+    experiments_column_type='map_struct',
 )
 
 active_hours = Metric(

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -24,7 +24,7 @@ main_summary = DataSource(
 events = DataSource(
     name='events',
     from_expr="`moz-fx-data-shared-prod.telemetry.events`",
-    experiments_column_type='map_struct',
+    experiments_column_type='native',
 )
 
 active_hours = Metric(


### PR DESCRIPTION
In order to add 'connect_fxa' as a metric, I had to un-break the join to the `events` table (the changes in `metrics/__init__.py`).

I applied this quickly to [an existing onboarding experiment](https://colab.research.google.com/drive/1fQQVj7yB3x9NHIRxI371_Pk0VEGxXV9W) and the metric result was nonzero and plausible (to me).

@tdsmith: can you please review the changes to `__init__.py` - it would be particularly appreciated if you can think of a better name than 'map_struct'.

@irrationalagent: could you please check that the metric is defined correctly and named sensibly? My [application notebook](https://colab.research.google.com/drive/1fQQVj7yB3x9NHIRxI371_Pk0VEGxXV9W) has the full generated query, if you want to see how the `Metric` object is used to form a concrete SQL query.