### PR TITLE
Remove py27 support - abandon ship.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,11 +39,6 @@ test_settings: &test_settings
 version: 2
 jobs:
 
-  py27:
-    <<: *test_settings
-    docker:
-      - image: python:2.7-stretch
-
   py37:
     <<: *test_settings
     docker:
@@ -51,7 +46,7 @@ jobs:
 
   lint:
     docker:
-      - image: python:2.7-stretch
+      - image: python:3.7-stretch
     steps:
     - checkout
     - run:
@@ -64,7 +59,7 @@ jobs:
   # below for trigger logic.
   deploy:
     docker:
-      - image: python:2.7-stretch
+      - image: python:3.7-stretch
     steps:
       - checkout
       - run:
@@ -131,7 +126,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - py27
       - py37
       - lint
       - docs

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ CircleCI runs for continuous integration by
 and invoking:
 
 ```bash
-circleci build --job py27
+circleci build --job py37
 ```
 
 See [.circleci/config.yml](https://github.com/mozilla/mozanalysis/blob/master/.circleci/config.yml)

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # This file is referenced when tox is invoked in bin/test or .circleci/config.yml
 
 [tox]
-envlist = py27,py37,docs,lint  # CircleCI jobs override the envlist; see .circleci/config.yml
+envlist = py37,docs,lint  # CircleCI jobs override the envlist; see .circleci/config.yml
 
 [pytest]
 addopts =


### PR DESCRIPTION
Tests started failing on py27, in areas untouched by recent commits. The ship is sinking, let's get off it.

I have little idea what I'm doing w.r.t. packaging, but after making these changes `tox` ran successfully from scratch and I could find no further references to 'py2' or 'python2' in the project, so this seems to have worked?