### PR TITLE
Remove explicit object inheritance

### DIFF
--- a/src/mozanalysis/bq.py
+++ b/src/mozanalysis/bq.py
@@ -16,7 +16,7 @@ def sanitize_table_name_for_bq(table_name):
         + of_good_character_but_possibly_verbose[-500:]
 
 
-class BigQueryContext(object):
+class BigQueryContext:
     """Holds a BigQuery client, and some configuration.
 
     Args:

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -8,7 +8,7 @@ from mozanalysis.utils import add_days, date_sub, hash_ish
 
 
 @attr.s(frozen=True, slots=True)
-class Experiment(object):
+class Experiment:
     """Query experiment data; store experiment metadata.
 
     The methods here query data in a way compatible with the following
@@ -390,7 +390,7 @@ class Experiment(object):
 
 
 @attr.s(frozen=True, slots=True)
-class TimeLimits(object):
+class TimeLimits:
     """Internal object containing various time limits.
 
     Instantiated and used by the ``Experiment`` class; end users
@@ -590,7 +590,7 @@ class TimeLimits(object):
 
 
 @attr.s(frozen=True, slots=True)
-class AnalysisWindow(object):
+class AnalysisWindow:
     """Represents the range of days in which to measure a metric.
 
     The range is measured in "days after enrollment", and is inclusive.
@@ -616,7 +616,7 @@ class AnalysisWindow(object):
 
 
 @attr.s(frozen=True, slots=True)
-class TimeSeriesResult(object):
+class TimeSeriesResult:
     """Result from a time series query.
 
     For each analysis window, this object lets us get a dataframe in

--- a/src/mozanalysis/metrics/__init__.py
+++ b/src/mozanalysis/metrics/__init__.py
@@ -5,7 +5,7 @@ import attr
 
 
 @attr.s(frozen=True, slots=True)
-class DataSource(object):
+class DataSource:
     """Represents a table or view, from which Metrics may be defined.
 
     Args:
@@ -151,7 +151,7 @@ class DataSource(object):
 
 
 @attr.s(frozen=True, slots=True)
-class Metric(object):
+class Metric:
     """Represents an experiment metric.
 
     Needs to be combined with an analysis window to be measurable!


### PR DESCRIPTION
All classes inherit from object in Python 3. It's a brave new world!

https://twitter.com/electrolemon/status/1043183150216765440