### PR TITLE
Allow Metrics to be rebased on other DataSources

### DIFF
--- a/src/mozanalysis/metrics/__init__.py
+++ b/src/mozanalysis/metrics/__init__.py
@@ -160,6 +160,14 @@ class Metric(object):
     data_source = attr.ib(type=DataSource)
     select_expr = attr.ib(type=str)
 
+    def from_data_source(self, data_source: DataSource) -> "Metric":
+        """Returns an instance of the Metric drawing from a different DataSource.
+
+        This is particularly useful for Glean, where pings from e.g. Fenix
+        and Fenix Nightly are sent to different tables with identical schemas.
+        """
+        return attr.evolve(self, data_source=data_source)
+
 
 def agg_sum(select_expr):
     """Return a SQL fragment for the sum over the data, with 0-filled nulls.


### PR DESCRIPTION
Sometimes you have tables with identical schemas and need to prefer one or the other in different contexts. These could be using `telemetry_live` tables, or using a Fenix Nightly table vs a Fenix release table. This helper facilitates that.