### PR TITLE
COALESCE segments to remove NULL values

### DIFF
--- a/src/mozanalysis/segments/desktop.py
+++ b/src/mozanalysis/segments/desktop.py
@@ -39,20 +39,38 @@ tmp_segment_regular_users_v2 = """  CASE
 regular_users_v2 = Segment(
     name='regular_users_v2',
     data_source=clients_last_seen_lag_1_day,
-    # select_expr="MAX(segment_regular_users_v2 = 'regular_users_v2')",
-    select_expr=f"MAX({tmp_segment_regular_users_v2} = 'regular_users_v2')",
+    # select_expr="""MAX(
+    #     COALESCE(segment_regular_users_v2, 'new_irregular_users_v2')
+    #     = 'regular_users_v2'
+    # )""",
+    select_expr=f"""MAX(
+        COALESCE({tmp_segment_regular_users_v2}, 'new_irregular_users_v2')
+        = 'regular_users_v2'
+    )""",
 )
 
 semi_regular_users_v2 = Segment(
     name='semi_regular_users_v2',
     data_source=clients_last_seen_lag_1_day,
-    # select_expr="MAX(segment_regular_users_v2 = 'semi_regular_users_v2')",
-    select_expr=f"MAX({tmp_segment_regular_users_v2} = 'semi_regular_users_v2')",
+    # select_expr="""MAX(
+    #     COALESCE(segment_regular_users_v2, 'new_irregular_users_v2')
+    #     = 'semi_regular_users_v2'
+    # )""",
+    select_expr=f"""MAX(
+        COALESCE({tmp_segment_regular_users_v2}, 'new_irregular_users_v2')
+        = 'semi_regular_users_v2'
+    )""",
 )
 
 new_irregular_users_v2 = Segment(
     name='new_irregular_users_v2',
     data_source=clients_last_seen_lag_1_day,
-    # select_expr="MAX(segment_regular_users_v2 = 'new_irregular_users_v2')",
-    select_expr=f"MAX({tmp_segment_regular_users_v2} = 'new_irregular_users_v2')",
+    # select_expr="""MAX(
+    #     COALESCE(segment_regular_users_v2, 'new_irregular_users_v2')
+    #     = 'new_irregular_users_v2'
+    # )""",
+    select_expr=f"""MAX(
+        COALESCE({tmp_segment_regular_users_v2}, 'new_irregular_users_v2')
+        = 'new_irregular_users_v2'
+    )""",
 )


### PR DESCRIPTION
Because `clients_last_seen` is constructed from the `main` ping, and our enrollments are obtained from the `events` ping,there are enrollments without a `clients_last_seen` row that matches the submission date.

This only happens for users without any (main ping) activity in the past 28 days. Therefore these users belong in `new_irregular_users_v2`.

This problem will persist even once the segments are in the ETL.

There are terser solutions (e.g. `MAX(...=...) IS TRUE` for two segments to map `NULL` to `FALSE`), but I figured that this verbose form was the most readily understandable.