### PR TITLE
add cfr DataSource

### DIFF
--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -56,7 +56,7 @@ cfr = DataSource(
     from_expr="""(
                 SELECT
                     *,
-                    DATE(submission_timestamp) AS submission_date                
+                    DATE(submission_timestamp) AS submission_date
                 FROM `moz-fx-data-derived-datasets`.messaging_system.cfr
             )""",
 )

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -51,6 +51,16 @@ crash = DataSource(
     experiments_column_type="native",
 )
 
+cfr = DataSource(
+    name='cfr',
+    from_expr="""(
+                SELECT
+                    *,
+                    DATE(submission_timestamp) AS submission_date                
+                FROM `moz-fx-data-derived-datasets`.messaging_system.cfr
+            )""",
+)
+
 active_hours = Metric(
     name='active_hours',
     data_source=clients_daily,

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -59,6 +59,7 @@ cfr = DataSource(
                     DATE(submission_timestamp) AS submission_date
                 FROM `moz-fx-data-derived-datasets`.messaging_system.cfr
             )""",
+            experiments_column_type="native",
 )
 
 active_hours = Metric(

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -59,7 +59,7 @@ cfr = DataSource(
                     DATE(submission_timestamp) AS submission_date
                 FROM `moz-fx-data-derived-datasets`.messaging_system.cfr
             )""",
-            experiments_column_type="native",
+    experiments_column_type="native",
 )
 
 active_hours = Metric(


### PR DESCRIPTION
Adds a datasource pointing to the `messaging_system.cfr` which contains the CFR metrics events.

A couple notes: the `experiments` column on this table was recently fixed, I believe it is of type `simple` (the default for the DataSource class).

I am not adding metrics here, because there are additional variable(s) `bucket_id` and `message_id` that are required to filter down to the CFR campaign of interest (in a CFR experiment, an enrolled user may see multiple CFR campaigns, so its not possible to just pull all rows from the CFR table matching an enrolled client_id).

For example, for a recent experiment my metric definition looked like this:
```python
cfr_impression = Metric(
    name='cfr_impression',
    data_source=cfr,
    select_expr=agg_any("""event = 'IMPRESSION' 
    AND bucket_id = {}
    AND message_id = {}""".format(CFR_BUCKET_ID, CFR_MESSAGE_ID))
)
```

bucket_id and message_id will vary with experiment, making it difficult to codify them in the Metrics definition file. 

We could consider extending the `Metric` class to a `CfrMetric` class that takes bucket_id and message_id as additional properties, but IMO for now that would add a bunch more boilerplate without too much of a gain in convenience. I will be adding a template notebook for CFR analysis to dscontrib so people can copypasta example metrics from there, if they want. 
