### PR TITLE
Update usage regularity segments to v3.

### DIFF
--- a/src/mozanalysis/segments/desktop.py
+++ b/src/mozanalysis/segments/desktop.py
@@ -13,64 +13,18 @@ clients_last_seen_lag_1_day = SegmentDataSource(
 )
 
 
-# Before https://github.com/mozilla/bigquery-etl/pull/825/ is merged,
-# we gotta do our own transforms
-tmp_segment_regular_users_v2 = """  CASE
-  WHEN
-    BIT_COUNT(days_visited_5_uri_bits & 0x0FFFFFFE) = 0
-  THEN
-    'new_irregular_users_v2'
-  WHEN
-    BIT_COUNT(days_visited_5_uri_bits & 0x0FFFFFFE)
-    BETWEEN 1
-    AND 7
-  THEN
-    'semi_regular_users_v2'
-  WHEN
-    BIT_COUNT(days_visited_5_uri_bits & 0x0FFFFFFE)
-    BETWEEN 8
-    AND 27
-  THEN
-    'regular_users_v2'
-  END
-"""
-
-
-regular_users_v2 = Segment(
-    name='regular_users_v2',
+regular_users_v3 = Segment(
+    name='regular_users_v3',
     data_source=clients_last_seen_lag_1_day,
-    # select_expr="""MAX(
-    #     COALESCE(segment_regular_users_v2, 'new_irregular_users_v2')
-    #     = 'regular_users_v2'
-    # )""",
     select_expr=f"""MAX(
-        COALESCE({tmp_segment_regular_users_v2}, 'new_irregular_users_v2')
-        = 'regular_users_v2'
+        BIT_COUNT(COALESCE(days_seen_bits, 0) & 0x0FFFFFFE) >= 14
     )""",
 )
 
-semi_regular_users_v2 = Segment(
-    name='semi_regular_users_v2',
+new_or_resurrected_v3 = Segment(
+    name='new_or_resurrected_v3',
     data_source=clients_last_seen_lag_1_day,
-    # select_expr="""MAX(
-    #     COALESCE(segment_regular_users_v2, 'new_irregular_users_v2')
-    #     = 'semi_regular_users_v2'
-    # )""",
     select_expr=f"""MAX(
-        COALESCE({tmp_segment_regular_users_v2}, 'new_irregular_users_v2')
-        = 'semi_regular_users_v2'
-    )""",
-)
-
-new_irregular_users_v2 = Segment(
-    name='new_irregular_users_v2',
-    data_source=clients_last_seen_lag_1_day,
-    # select_expr="""MAX(
-    #     COALESCE(segment_regular_users_v2, 'new_irregular_users_v2')
-    #     = 'new_irregular_users_v2'
-    # )""",
-    select_expr=f"""MAX(
-        COALESCE({tmp_segment_regular_users_v2}, 'new_irregular_users_v2')
-        = 'new_irregular_users_v2'
+        BIT_COUNT(COALESCE(days_seen_bits, 0) & 0x0FFFFFFE) = 0
     )""",
 )

--- a/src/mozanalysis/segments/desktop.py
+++ b/src/mozanalysis/segments/desktop.py
@@ -5,7 +5,7 @@
 from mozanalysis.segments import Segment, SegmentDataSource
 
 
-clients_last_seen_lag_1_day = SegmentDataSource(
+clients_last_seen = SegmentDataSource(
     name='clients_last_seen',
     from_expr="`moz-fx-data-shared-prod.telemetry.clients_last_seen`",
     window_start=0,
@@ -15,7 +15,7 @@ clients_last_seen_lag_1_day = SegmentDataSource(
 
 regular_users_v3 = Segment(
     name='regular_users_v3',
-    data_source=clients_last_seen_lag_1_day,
+    data_source=clients_last_seen,
     select_expr=f"""MAX(
         BIT_COUNT(COALESCE(days_seen_bits, 0) & 0x0FFFFFFE) >= 14
     )""",
@@ -23,7 +23,7 @@ regular_users_v3 = Segment(
 
 new_or_resurrected_v3 = Segment(
     name='new_or_resurrected_v3',
-    data_source=clients_last_seen_lag_1_day,
+    data_source=clients_last_seen,
     select_expr=f"""MAX(
         BIT_COUNT(COALESCE(days_seen_bits, 0) & 0x0FFFFFFE) = 0
     )""",

--- a/tests/test_segment_libraries.py
+++ b/tests/test_segment_libraries.py
@@ -6,7 +6,7 @@ import mozanalysis.metrics.desktop as mmd
 
 
 def test_imported_ok():
-    assert msd.regular_users_v2
+    assert msd.regular_users_v3
 
 
 def test_sql_not_detectably_malformed():


### PR DESCRIPTION
Docs for these segments are [on DTMO](https://docs.telemetry.mozilla.org/concepts/segments.html#regular-users-v3).

Here's a [colab notebook](https://colab.research.google.com/drive/1C1y3DbZ4vN1-gIh5JrIcQL8c8kZv8WoK) that demonstrates that this generates valid SQL that executes against our DB!