### PR TITLE
Add and update segments

### DIFF
--- a/src/mozanalysis/segments/desktop.py
+++ b/src/mozanalysis/segments/desktop.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from mozanalysis.metrics.desktop import agg_any
+from mozanalysis.metrics import agg_any
 from mozanalysis.segments import Segment, SegmentDataSource
 
 

--- a/src/mozanalysis/segments/desktop.py
+++ b/src/mozanalysis/segments/desktop.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from mozanalysis.metrics.desktop import agg_any
 from mozanalysis.segments import Segment, SegmentDataSource
 
 
@@ -16,15 +17,11 @@ clients_last_seen = SegmentDataSource(
 regular_users_v3 = Segment(
     name='regular_users_v3',
     data_source=clients_last_seen,
-    select_expr="""MAX(
-        BIT_COUNT(COALESCE(days_seen_bits, 0) & 0x0FFFFFFE) >= 14
-    )""",
+    select_expr=agg_any('is_regular_user_v3'),
 )
 
 new_or_resurrected_v3 = Segment(
     name='new_or_resurrected_v3',
     data_source=clients_last_seen,
-    select_expr="""MAX(
-        BIT_COUNT(COALESCE(days_seen_bits, 0) & 0x0FFFFFFE) = 0
-    )""",
+    select_expr="LOGICAL_OR(COALESCE(is_new_or_resurrected_v3, TRUE))",
 )

--- a/src/mozanalysis/segments/desktop.py
+++ b/src/mozanalysis/segments/desktop.py
@@ -25,3 +25,16 @@ new_or_resurrected_v3 = Segment(
     data_source=clients_last_seen,
     select_expr="LOGICAL_OR(COALESCE(is_new_or_resurrected_v3, TRUE))",
 )
+
+
+weekday_regular_v1 = Segment(
+    name='weekday_regular_v1',
+    data_source=clients_last_seen,
+    select_expr=agg_any('is_weekday_regular_v1'),
+)
+
+allweek_regular_v1 = Segment(
+    name='allweek_regular_v1',
+    data_source=clients_last_seen,
+    select_expr=agg_any('is_allweek_regular_v1'),
+)


### PR DESCRIPTION
Add new segments:
* `weekday_regular_v1`
* `allweek_regular_v1`

Update `regular_users_v3` and `new_or_resurrected_v3` to use the ETL segment definitions, now that they exist.

[Here is a notebook](https://colab.research.google.com/drive/1QTfvgdrseFTC-E4iKnUUNd2tvGsazoB5) that applies the code added/edited here to produce sensible-seeming numbers.