### PR TITLE
normandy_events datasource for unenroll metric

### DIFF
--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -62,6 +62,16 @@ cfr = DataSource(
     experiments_column_type="native",
 )
 
+normandy_events = DataSource(
+    name='normandy_events',
+    from_expr="""(
+        SELECT
+            *
+        FROM `moz-fx-data-shared-prod`.telemetry.events
+        WHERE event_category = 'normandy'
+    )""",
+)
+
 active_hours = Metric(
     name='active_hours',
     data_source=clients_daily,
@@ -112,7 +122,7 @@ organic_search_count = Metric(
 
 unenroll = Metric(
     name='unenroll',
-    data_source=events,
+    data_source=normandy_events,
     select_expr=agg_any("""
                 event_category = 'normandy'
                 AND event_method = 'unenroll'

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -27,6 +27,19 @@ events = DataSource(
     experiments_column_type='native',
 )
 
+# The telemetry.events table is clustered by event_category.
+# Normandy accounts for about 10% of event volume, so this dramatically
+# reduces bytes queried compared to counting rows from the generic events DataSource.
+normandy_events = DataSource(
+    name='normandy_events',
+    from_expr="""(
+        SELECT
+            *
+        FROM `moz-fx-data-shared-prod`.telemetry.events
+        WHERE event_category = 'normandy'
+    )""",
+)
+
 main = DataSource(
     name='main',
     from_expr="""(
@@ -60,16 +73,6 @@ cfr = DataSource(
                 FROM `moz-fx-data-derived-datasets`.messaging_system.cfr
             )""",
     experiments_column_type="native",
-)
-
-normandy_events = DataSource(
-    name='normandy_events',
-    from_expr="""(
-        SELECT
-            *
-        FROM `moz-fx-data-shared-prod`.telemetry.events
-        WHERE event_category = 'normandy'
-    )""",
 )
 
 active_hours = Metric(


### PR DESCRIPTION
In pensieve, calculating the unenroll metric on a daily basis is quite expensive since currently `telemetry.events` is queried directly without any filtering. If we make use of  the `event_category` partitioning running the query only costs us a fraction.

I'm not sure if unenroll results are still correct with these changes though...