### PR TITLE
Emit Sphinx docs for desktop metrics

### DIFF
--- a/docs/api/metrics/desktop.rst
+++ b/docs/api/metrics/desktop.rst
@@ -1,4 +1,5 @@
 :mod:`mozanalysis.metrics.desktop`
 ----------------------------------
 
-See the source for the included metrics. Sphinx seems to be uncooperative displaying source code that does not define functions or classes - so view the latest source `on github <https://github.com/mozilla/mozanalysis/tree/master/src/mozanalysis/metrics/desktop.py>`_.
+.. automodule:: mozanalysis.metrics.desktop
+    :members:

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -6,31 +6,40 @@ from textwrap import dedent
 from mozanalysis.metrics import Metric, DataSource, agg_sum, agg_any
 
 
+#: DataSource: The clients_daily table.
 clients_daily = DataSource(
     name='clients_daily',
     from_expr="`moz-fx-data-shared-prod.telemetry.clients_daily`",
 )
 
+#: DataSource: The `search_clients_daily`_ table.
+#: This table unpacks search counts from the main ping;
+#: it contains one row per (client_id, submission_date, engine, source).
+#: 
+#: .. _`search_clients_daily`: https://docs.telemetry.mozilla.org/datasets/search/search_clients_daily/reference.html
 search_clients_daily = DataSource(
     name='search_clients_daily',
     from_expr='`moz-fx-data-shared-prod.search.search_clients_daily`',
     experiments_column_type=None,
 )
 
+#: DataSource: The main_summary table.
 main_summary = DataSource(
     name='main_summary',
     from_expr="`moz-fx-data-shared-prod.telemetry.main_summary`"
 )
 
+#: DataSource: The events table.
 events = DataSource(
     name='events',
     from_expr="`moz-fx-data-shared-prod.telemetry.events`",
     experiments_column_type='native',
 )
 
-# The telemetry.events table is clustered by event_category.
-# Normandy accounts for about 10% of event volume, so this dramatically
-# reduces bytes queried compared to counting rows from the generic events DataSource.
+#: DataSource: Normandy events; a subset of the events table.
+#: The telemetry.events table is clustered by event_category.
+#: Normandy accounts for about 10% of event volume, so this dramatically
+#: reduces bytes queried compared to counting rows from the generic events DataSource.
 normandy_events = DataSource(
     name='normandy_events',
     from_expr="""(
@@ -42,6 +51,7 @@ normandy_events = DataSource(
     experiments_column_type='native',
 )
 
+#: DataSource: The telemetry.main ping table.
 main = DataSource(
     name='main',
     from_expr="""(
@@ -54,6 +64,7 @@ main = DataSource(
     experiments_column_type="native",
 )
 
+#: DataSource: The telemetry.crash ping table.
 crash = DataSource(
     name='crash',
     from_expr="""(
@@ -66,6 +77,7 @@ crash = DataSource(
     experiments_column_type="native",
 )
 
+#: DataSource: The ``messaging_system.cfr`` table.
 cfr = DataSource(
     name='cfr',
     from_expr="""(
@@ -77,6 +89,7 @@ cfr = DataSource(
     experiments_column_type="native",
 )
 
+#: Metric: ...
 active_hours = Metric(
     name='active_hours',
     data_source=clients_daily,
@@ -89,6 +102,7 @@ active_hours = Metric(
     """),
 )
 
+#: Metric: ...
 uri_count = Metric(
     name='uri_count',
     data_source=clients_daily,
@@ -100,6 +114,7 @@ uri_count = Metric(
     """),
 )
 
+#: Metric: ...
 search_count = Metric(
     name='search_count',
     data_source=search_clients_daily,
@@ -113,6 +128,7 @@ search_count = Metric(
     """),  # noqa:E501
 )
 
+#: Metric: ...
 tagged_search_count = Metric(
     name='tagged_search_count',
     data_source=search_clients_daily,
@@ -127,6 +143,7 @@ tagged_search_count = Metric(
     """),  # noqa:E501
 )
 
+#: Metric: ...
 tagged_follow_on_search_count = Metric(
     name='tagged_follow_on_search_count',
     data_source=search_clients_daily,
@@ -141,6 +158,7 @@ tagged_follow_on_search_count = Metric(
     """),  # noqa:E501
 )
 
+#: Metric: ...
 ad_clicks = Metric(
     name='ad_clicks',
     data_source=search_clients_daily,
@@ -152,6 +170,7 @@ ad_clicks = Metric(
     """),
 )
 
+#: Metric: ...
 searches_with_ads = Metric(
     name='searches_with_ads',
     data_source=search_clients_daily,
@@ -165,6 +184,7 @@ searches_with_ads = Metric(
     """),  # noqa:E501
 )
 
+#: Metric: ...
 organic_search_count = Metric(
     name='organic_search_count',
     data_source=search_clients_daily,
@@ -178,6 +198,7 @@ organic_search_count = Metric(
     """),  # noqa:E501
 )
 
+#: Metric: ...
 unenroll = Metric(
     name='unenroll',
     data_source=normandy_events,
@@ -192,6 +213,7 @@ unenroll = Metric(
     """),
 )
 
+#: Metric: ...
 view_about_logins = Metric(
     name='view_about_logins',
     data_source=events,
@@ -205,6 +227,7 @@ view_about_logins = Metric(
     """),
 )
 
+#: Metric: ...
 view_about_protections = Metric(
     name='view_about_protections',
     data_source=events,
@@ -218,6 +241,7 @@ view_about_protections = Metric(
     """),
 )
 
+#: Metric: ...
 connect_fxa = Metric(
     name='connect_fxa',
     data_source=events,

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -15,8 +15,9 @@ clients_daily = DataSource(
 #: DataSource: The `search_clients_daily`_ table.
 #: This table unpacks search counts from the main ping;
 #: it contains one row per (client_id, submission_date, engine, source).
-#: 
-#: .. _`search_clients_daily`: https://docs.telemetry.mozilla.org/datasets/search/search_clients_daily/reference.html
+#:
+#: .. _`search_clients_daily`: https://docs.telemetry.mozilla.org/datasets/
+#:    search/search_clients_daily/reference.html
 search_clients_daily = DataSource(
     name='search_clients_daily',
     from_expr='`moz-fx-data-shared-prod.search.search_clients_daily`',


### PR DESCRIPTION
It turns out Sphinx refuses to emit anything for undocumented module constants. But we can add trivial documentation.

If anyone gets bored enough, I think the proper thing to do here is to write a Sphinx extension that hooks the autodoc [process-docstring](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#docstring-preprocessing) event and replaces "..." with the `description` field, though I'm not sure how to reason about the description containing Markdown and the Sphinx docs being more or less in RST -- eh!