### PR TITLE
Add a lower-is-better flag

### DIFF
--- a/src/mozanalysis/metrics/__init__.py
+++ b/src/mozanalysis/metrics/__init__.py
@@ -204,6 +204,7 @@ class Metric:
     select_expr = attr.ib(type=str)
     friendly_name = attr.ib(type=Optional[str], default=None)
     description = attr.ib(type=Optional[str], default=None)
+    lower_is_better = attr.ib(type=bool, default=False)
 
     def from_data_source(self, data_source: DataSource) -> "Metric":
         """Returns an instance of the Metric drawing from a different DataSource.

--- a/src/mozanalysis/metrics/__init__.py
+++ b/src/mozanalysis/metrics/__init__.py
@@ -204,7 +204,7 @@ class Metric:
     select_expr = attr.ib(type=str)
     friendly_name = attr.ib(type=Optional[str], default=None)
     description = attr.ib(type=Optional[str], default=None)
-    lower_is_better = attr.ib(type=bool, default=False)
+    bigger_is_better = attr.ib(type=bool, default=True)
 
     def from_data_source(self, data_source: DataSource) -> "Metric":
         """Returns an instance of the Metric drawing from a different DataSource.

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -225,6 +225,7 @@ unenroll = Metric(
     description=dedent("""\
         Counts the number of clients with an experiment unenrollment event.
     """),
+    lower_is_better=True,
 )
 
 #: Metric: ...

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -225,7 +225,7 @@ unenroll = Metric(
     description=dedent("""\
         Counts the number of clients with an experiment unenrollment event.
     """),
-    lower_is_better=True,
+    bigger_is_better=False,
 )
 
 #: Metric: ...

--- a/src/mozanalysis/metrics/fenix.py
+++ b/src/mozanalysis/metrics/fenix.py
@@ -72,7 +72,7 @@ user_reload_count = Metric(
     + "mozfun.map.get_key('event.extra', 'item') = 'reload')",
     friendly_name="Pages reloaded",
     description="Counts the number of times a client reloaded a page.",
-    lower_is_better=True,
+    bigger_is_better=False,
 )
 
 baseline_ping_count = Metric(

--- a/src/mozanalysis/metrics/fenix.py
+++ b/src/mozanalysis/metrics/fenix.py
@@ -72,6 +72,7 @@ user_reload_count = Metric(
     + "mozfun.map.get_key('event.extra', 'item') = 'reload')",
     friendly_name="Pages reloaded",
     description="Counts the number of times a client reloaded a page.",
+    lower_is_better=True,
 )
 
 baseline_ping_count = Metric(


### PR DESCRIPTION
Dashboards shouldn't look excited when we get more of a bad thing, or when performance timings increase.

Sometimes this will depend on the context of the experiment; if the wrong assertion is made here, folks can make a copy of the metric with the bit flipped.

cf https://github.com/mozilla/jetstream/issues/252