### PR TITLE
Fix the `days_of_use` metric.

### DIFF
--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -306,7 +306,7 @@ pocket_click_count = Metric(
 days_of_use = Metric(
     name="days_of_use",
     data_source=clients_daily,
-    select_expr="COUNT(*)",
+    select_expr="COUNT(ds.submission_date)",
     friendly_name="Days of use",
     description="The number of days in the interval that each client sent a main ping."
 )


### PR DESCRIPTION
@SuYoungHong noticed that the results of the `days_of_use` metric introduced in PR #105 were very suspicious.

The `COUNT(*)` was counting enrollments even when they had no row in `clients_daily`. Oops.

Instead, we need to `COUNT()` a non-null column from `clients_daily`; `COUNT(ds.submission_date)` seems to be the best for communicating what this metric does? And it's not worth adding a `DISTINCT` because it's implied by `clients_daily` and the lack of other joins?

I haven't tried this code yet but I've asked Su to do so in [this notebook](https://colab.research.google.com/drive/1E-f35o3DE6FIdnmNjs7eEA413lkNjtLh).