### PR TITLE
Materialize enrollments table

### DIFF
--- a/src/mozanalysis/bq.py
+++ b/src/mozanalysis/bq.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import re
 from google.cloud import bigquery
-from google.api_core.exceptions import Conflict, NotFound
+from google.api_core.exceptions import NotFound
 
 
 def sanitize_table_name_for_bq(table_name):
@@ -31,33 +31,6 @@ class BigQueryContext:
         self.project_id = project_id
         self.client = bigquery.Client(project=project_id)
 
-    def run_query(self, sql, results_table=None):
-        """Run a query and return the result.
-
-        If ``results_table`` is provided, then save the results
-        into there (or just query from there if it already exists).
-
-        Returns a ``google.cloud.bigquery.table.RowIterator``
-        """
-        if not results_table:
-            return self.client.query(sql).result()
-
-        try:
-            full_res = self.client.query(
-                sql,
-                job_config=bigquery.QueryJobConfig(
-                    destination=self.client.dataset(
-                        self.dataset_id
-                    ).table(results_table)
-                )
-            ).result()
-            print('Saved into', results_table)
-            return full_res
-
-        except Conflict:
-            print("Full results table already exists. Reusing", results_table)
-            return self.client.list_rows(self.fully_qualify_table_name(results_table))
-
     def run_script_or_fetch(self, sql, results_table):
         """Runs a BigQuery SQL script and returns a RowIterator for results_table.
         The script is assumed to create a table named results_table after completing
@@ -74,11 +47,14 @@ class BigQueryContext:
         fqtn = self.fully_qualify_table_name(results_table)
 
         try:
-            return self.client.list_rows(fqtn)
+            cached = self.client.list_rows(fqtn)
+            print("Full results table already exists. Reusing", results_table)
+            return cached
         except NotFound:
             pass
 
         self.client.query(sql).result()
+        print('Saved into', results_table)
         return self.client.list_rows(fqtn)
 
     def fully_qualify_table_name(self, table_name):

--- a/src/mozanalysis/bq.py
+++ b/src/mozanalysis/bq.py
@@ -56,11 +56,7 @@ class BigQueryContext:
 
         except Conflict:
             print("Full results table already exists. Reusing", results_table)
-            return self.client.query(
-                "SELECT * FROM {}".format(
-                    self.fully_qualify_table_name(results_table)
-                )
-            ).result()
+            return self.client.list_rows(self.fully_qualify_table_name(results_table))
 
     def run_script_or_fetch(self, sql, results_table):
         """Runs a BigQuery SQL script and returns a RowIterator for results_table.

--- a/src/mozanalysis/bq.py
+++ b/src/mozanalysis/bq.py
@@ -62,20 +62,20 @@ class BigQueryContext:
                 )
             ).result()
 
-    def run_script_or_fetch(self, sql, destination_table):
-        """Runs a BigQuery SQL script and returns a RowIterator for destination_table.
-        The script is assumed to create a table named destination_table after completing
-        succesfully. If destination_table already exists, a RowIterator for the
+    def run_script_or_fetch(self, sql, results_table):
+        """Runs a BigQuery SQL script and returns a RowIterator for results_table.
+        The script is assumed to create a table named results_table after completing
+        succesfully. If results_table already exists, a RowIterator for the
         existing table will be returned without invoking the script.
 
-        destination_table is assumed to be an unqualified table name without
+        results_table is assumed to be an unqualified table name without
         a project or dataset reference.
 
         Learn more about BigQuery scripting at
         https://cloud.google.com/bigquery/docs/reference/standard-sql/scripting.
         """
 
-        fqtn = self.fully_qualify_table_name(destination_table)
+        fqtn = self.fully_qualify_table_name(results_table)
 
         try:
             return self.client.list_rows(fqtn)

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -313,18 +313,21 @@ class Experiment:
         )
 
         return """
-    WITH analysis_windows AS (
-        {analysis_windows_query}
-    ),
-    raw_enrollments AS ({enrollments_query}),
-    segmented_enrollments AS ({segments_query}),
-    enrollments AS (
-        SELECT
-            e.*,
-            aw.*
-        FROM segmented_enrollments e
-        CROSS JOIN analysis_windows aw
-    )
+    CREATE TEMPORARY TABLE enrollments AS (
+        WITH analysis_windows AS (
+            {analysis_windows_query}
+        ),
+        raw_enrollments AS ({enrollments_query}),
+        segmented_enrollments AS ({segments_query}),
+        enrollments AS (
+            SELECT
+                e.*,
+                aw.*
+            FROM segmented_enrollments e
+            CROSS JOIN analysis_windows aw
+        )
+    );
+
     SELECT
         enrollments.*,
         {metrics_columns}

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -176,7 +176,7 @@ class Experiment:
         sql_to_be_hashed = self.build_query(
             metric_list=metric_list,
             time_limits=time_limits,
-            destination_table="",
+            results_table="",
             enrollments_query_type=enrollments_query_type,
             custom_enrollments_query=custom_enrollments_query,
             segment_list=segment_list,
@@ -189,7 +189,7 @@ class Experiment:
         sql = self.build_query(
             metric_list=metric_list,
             time_limits=time_limits,
-            destination_table=full_res_table_name,
+            results_table=full_res_table_name,
             enrollments_query_type=enrollments_query_type,
             custom_enrollments_query=custom_enrollments_query,
             segment_list=segment_list,
@@ -262,7 +262,7 @@ class Experiment:
         sql_to_be_hashed = self.build_query(
             metric_list=metric_list,
             time_limits=time_limits,
-            destination_table="",
+            results_table="",
             enrollments_query_type=enrollments_query_type,
             custom_enrollments_query=custom_enrollments_query,
             segment_list=segment_list,
@@ -275,7 +275,7 @@ class Experiment:
         sql = self.build_query(
             metric_list=metric_list,
             time_limits=time_limits,
-            destination_table=full_res_table_name,
+            results_table=full_res_table_name,
             enrollments_query_type=enrollments_query_type,
             custom_enrollments_query=custom_enrollments_query,
             segment_list=segment_list,
@@ -291,7 +291,7 @@ class Experiment:
         )
 
     def build_query(
-        self, *, metric_list, time_limits, destination_table,
+        self, *, metric_list, time_limits, results_table,
         enrollments_query_type='normandy', custom_enrollments_query=None,
         segment_list=None
     ) -> str:
@@ -307,7 +307,7 @@ class Experiment:
                 The metrics to analyze.
             time_limits (TimeLimits): An object describing the
                 interval(s) to query
-            destination_table (str): The name of the table to write
+            results_table (str): The name of the table to write
             enrollments_query_type ('normandy' or 'fenix-fallback'):
                 Specifies the query type to use to get the experiment's
                 enrollments, unless overridden by
@@ -356,7 +356,7 @@ class Experiment:
         )
     );
 
-    CREATE OR REPLACE TABLE {destination_table} AS (
+    CREATE OR REPLACE TABLE {results_table} AS (
         SELECT
             enrollments.*,
             {metrics_columns}
@@ -369,7 +369,7 @@ class Experiment:
             segments_query=segments_query,
             metrics_columns=',\n        '.join(metrics_columns),
             metrics_joins='\n'.join(metrics_joins),
-            destination_table=destination_table,
+            results_table=results_table,
         )
 
     @staticmethod

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -245,7 +245,7 @@ def test_query_not_detectably_malformed():
         metric_list=[],
         time_limits=tl,
         enrollments_query_type='normandy',
-        destination_table='destination',
+        results_table='destination',
     )
 
     sql_lint(sql)
@@ -265,7 +265,7 @@ def test_megaquery_not_detectably_malformed():
         metric_list=[m for m in mad.__dict__.values() if isinstance(m, mad.Metric)],
         time_limits=tl,
         enrollments_query_type='normandy',
-        destination_table='destination',
+        results_table='destination',
     )
 
     sql_lint(sql)
@@ -286,7 +286,7 @@ def test_segments_megaquery_not_detectably_malformed():
         segment_list=[s for s in msd.__dict__.values() if isinstance(s, msd.Segment)],
         time_limits=tl,
         enrollments_query_type='normandy',
-        destination_table='destination',
+        results_table='destination',
     )
 
     sql_lint(sql)
@@ -306,7 +306,7 @@ def test_query_not_detectably_malformed_fenix_fallback():
         metric_list=[],
         time_limits=tl,
         enrollments_query_type='fenix-fallback',
-        destination_table='destination',
+        results_table='destination',
     )
 
     sql_lint(sql)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -245,6 +245,7 @@ def test_query_not_detectably_malformed():
         metric_list=[],
         time_limits=tl,
         enrollments_query_type='normandy',
+        destination_table='destination',
     )
 
     sql_lint(sql)
@@ -264,6 +265,7 @@ def test_megaquery_not_detectably_malformed():
         metric_list=[m for m in mad.__dict__.values() if isinstance(m, mad.Metric)],
         time_limits=tl,
         enrollments_query_type='normandy',
+        destination_table='destination',
     )
 
     sql_lint(sql)
@@ -284,6 +286,7 @@ def test_segments_megaquery_not_detectably_malformed():
         segment_list=[s for s in msd.__dict__.values() if isinstance(s, msd.Segment)],
         time_limits=tl,
         enrollments_query_type='normandy',
+        destination_table='destination',
     )
 
     sql_lint(sql)
@@ -303,6 +306,7 @@ def test_query_not_detectably_malformed_fenix_fallback():
         metric_list=[],
         time_limits=tl,
         enrollments_query_type='fenix-fallback',
+        destination_table='destination',
     )
 
     sql_lint(sql)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -241,12 +241,11 @@ def test_query_not_detectably_malformed():
         num_dates_enrollment=8
     )
 
-    sql = exp.build_query(
+    sql = exp.build_query_template(
         metric_list=[],
         time_limits=tl,
         enrollments_query_type='normandy',
-        results_table='destination',
-    )
+    ).format(results_table='foo')
 
     sql_lint(sql)
 
@@ -261,12 +260,11 @@ def test_megaquery_not_detectably_malformed():
         num_dates_enrollment=8
     )
 
-    sql = exp.build_query(
+    sql = exp.build_query_template(
         metric_list=[m for m in mad.__dict__.values() if isinstance(m, mad.Metric)],
         time_limits=tl,
         enrollments_query_type='normandy',
-        results_table='destination',
-    )
+    ).format(results_table='foo')
 
     sql_lint(sql)
 
@@ -281,13 +279,12 @@ def test_segments_megaquery_not_detectably_malformed():
         num_dates_enrollment=8
     )
 
-    sql = exp.build_query(
+    sql = exp.build_query_template(
         metric_list=[m for m in mad.__dict__.values() if isinstance(m, mad.Metric)],
         segment_list=[s for s in msd.__dict__.values() if isinstance(s, msd.Segment)],
         time_limits=tl,
         enrollments_query_type='normandy',
-        results_table='destination',
-    )
+    ).format(results_table='foo')
 
     sql_lint(sql)
 
@@ -302,11 +299,10 @@ def test_query_not_detectably_malformed_fenix_fallback():
         num_dates_enrollment=8
     )
 
-    sql = exp.build_query(
+    sql = exp.build_query_template(
         metric_list=[],
         time_limits=tl,
         enrollments_query_type='fenix-fallback',
-        results_table='destination',
-    )
+    ).format(results_table='foo')
 
     sql_lint(sql)


### PR DESCRIPTION
Repeated references to the enrollments CTE seem to stress BigQuery out, giving rise to "Resources exceeded during query execution: Not enough resources for query planning - too many subqueries or query is too complex." errors.

If we use CREATE TEMPORARY TABLE to materialize the enrollments table before joining it everywhere, we get a scripting query with similar semantics and a calmer query planner.

~Caveat: I just realize this doesn't quite work yet, so leaving this as a draft for now; we can't set a destination-table name at execution time for a scripting query, so we have to replace the SELECT down there with another `CREATE TABLE {destination_table} AS` instead.~

cc @felixlawrence, @scholtzan 