### PR TITLE
Build hacks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ test_settings: &test_settings
         command: |
           # pyspark needs to run Java, so we install openjdk.
           apt-get update
-          apt-get install -y openjdk-8-jre-headless
+          apt-get install -y default-jre-headless
     - run: &run_tox_environment_matching_circleci_job_name
         name: Run tox job
         command: |
@@ -39,14 +39,19 @@ test_settings: &test_settings
 version: 2
 jobs:
 
-  py37:
+  py36:
     <<: *test_settings
     docker:
-      - image: python:3.7-stretch
+      - image: python:3.6-stretch
+
+  py38:
+    <<: *test_settings
+    docker:
+      - image: python:3.8-buster
 
   lint:
     docker:
-      - image: python:3.7-stretch
+      - image: python:3.8-buster
     steps:
     - checkout
     - run:
@@ -59,7 +64,7 @@ jobs:
   # below for trigger logic.
   deploy:
     docker:
-      - image: python:3.7-stretch
+      - image: python:3.8-buster
     steps:
       - checkout
       - run:
@@ -81,7 +86,7 @@ jobs:
 
   docs: &docs_settings
     docker:
-      - image: python:3.7-stretch
+      - image: python:3.8-buster
     steps:
       - checkout
       - run:
@@ -126,7 +131,8 @@ workflows:
   version: 2
   build:
     jobs:
-      - py37
+      - py36
+      - py38
       - lint
       - docs
       - docs-deploy:

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,10 @@ setup(
         'attrs',
         'numpy',
         'pandas',
+        'pyarrow',
         'scipy',
         'google-cloud-bigquery',
+        'google-cloud-bigquery-storage',
     ],
     setup_requires=['pytest-runner', 'setuptools_scm'],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # This file is referenced when tox is invoked in bin/test or .circleci/config.yml
 
 [tox]
-envlist = py37,docs,lint  # CircleCI jobs override the envlist; see .circleci/config.yml
+envlist = py36,py38,docs,lint  # CircleCI jobs override the envlist; see .circleci/config.yml
 
 [pytest]
 addopts =
@@ -31,6 +31,7 @@ commands =
     flake8 src/ tests/
 
 [testenv:docs]
+basepython = python3.8
 description = invoke sphinx-build to build the HTML docs
 extras =
     docs


### PR DESCRIPTION
- Declare pyarrow and google-cloud-bigquery-storage as dependencies so people get fast .to_dataframe() without extra work
- Build on interesting Python environments: Colab is 3.6 and Jetstream uses 3.8, so test those