### PR TITLE
Make metric datasets configurable at runtime

### DIFF
--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -85,6 +85,8 @@ class Experiment:
             factor '7' removes weekly seasonality, and the ``+1`` accounts
             for the fact that enrollment typically starts a few hours
             before UTC midnight.
+        app_id (str, optional): For a Glean app, the name of the BigQuery
+            dataset derived from its app ID, like `org_mozilla_fenix`.
 
     Attributes:
         experiment_slug (str): Name of the study, used to identify
@@ -103,6 +105,7 @@ class Experiment:
     experiment_slug = attr.ib()
     start_date = attr.ib()
     num_dates_enrollment = attr.ib(default=None)
+    app_id = attr.ib(default=None)
 
     def get_single_window_data(
         self, bq_context, metric_list, last_date_full_data,
@@ -432,7 +435,7 @@ class Experiment:
                 '{experiment_slug}'
             ).branch,
             DATE(MIN(b.submission_timestamp)) AS enrollment_date
-        FROM `moz-fx-data-shared-prod.org_mozilla_fenix.baseline` b
+        FROM `moz-fx-data-shared-prod.{dataset}.baseline` b
         WHERE
             DATE(b.submission_timestamp)
                 BETWEEN DATE_SUB('{first_enrollment_date}', INTERVAL 7 DAY)
@@ -447,6 +450,7 @@ class Experiment:
             experiment_slug=self.experiment_slug,
             first_enrollment_date=time_limits.first_enrollment_date,
             last_enrollment_date=time_limits.last_enrollment_date,
+            dataset=self.app_id or "org_mozilla_fenix",
         )
 
     def _build_metrics_query_bits(self, metric_list, time_limits):
@@ -462,7 +466,7 @@ class Experiment:
 
         for i, ds in enumerate(ds_metrics.keys()):
             query_for_metrics = ds.build_query(
-                ds_metrics[ds], time_limits, self.experiment_slug
+                ds_metrics[ds], time_limits, self.experiment_slug, self.app_id
             )
             metrics_joins.append(
                 """    LEFT JOIN (
@@ -527,7 +531,7 @@ class Experiment:
 
         for i, ds in enumerate(ds_segments.keys()):
             query_for_segments = ds.build_query(
-                ds_segments[ds], time_limits, self.experiment_slug
+                ds_segments[ds], time_limits, self.experiment_slug, self.app_id
             )
             segments_joins.append(
                 """    LEFT JOIN (

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -86,7 +86,7 @@ class Experiment:
             for the fact that enrollment typically starts a few hours
             before UTC midnight.
         app_id (str, optional): For a Glean app, the name of the BigQuery
-            dataset derived from its app ID, like `org_mozilla_fenix`.
+            dataset derived from its app ID, like `org_mozilla_firefox`.
 
     Attributes:
         experiment_slug (str): Name of the study, used to identify
@@ -450,7 +450,7 @@ class Experiment:
             experiment_slug=self.experiment_slug,
             first_enrollment_date=time_limits.first_enrollment_date,
             last_enrollment_date=time_limits.last_enrollment_date,
-            dataset=self.app_id or "org_mozilla_fenix",
+            dataset=self.app_id or "org_mozilla_firefox",
         )
 
     def _build_metrics_query_bits(self, metric_list, time_limits):

--- a/src/mozanalysis/metrics/__init__.py
+++ b/src/mozanalysis/metrics/__init__.py
@@ -43,7 +43,7 @@ class DataSource:
             `{dataset}` parameter.
     """
     name = attr.ib(validator=attr.validators.instance_of(str))
-    from_expr = attr.ib(validator=attr.validators.instance_of(str))
+    _from_expr = attr.ib(validator=attr.validators.instance_of(str))
     experiments_column_type = attr.ib(default='simple', type=str)
     client_id_column = attr.ib(default='client_id', type=str)
     submission_date_column = attr.ib(default='submission_date', type=str)
@@ -64,15 +64,22 @@ class DataSource:
         self.from_expr_for(None)
 
     def from_expr_for(self, dataset: Optional[str]) -> str:
+        """Expands the ``from_expr`` template for the given dataset.
+        If ``from_expr`` is not a template, returns ``from_expr``.
+
+        Args:
+            dataset (str or None): Dataset name to substitute
+                into the from expression.
+        """
         effective_dataset = dataset or self.default_dataset
         if effective_dataset is None:
             try:
-                return self.from_expr.format()
+                return self._from_expr.format()
             except Exception as e:
                 raise ValueError(
                     f"{self.name}: from_expr contains a dataset template but no value was provided."  # noqa:E501
                 ) from e
-        return self.from_expr.format(dataset=effective_dataset)
+        return self._from_expr.format(dataset=effective_dataset)
 
     @property
     def experiments_column_expr(self):

--- a/src/mozanalysis/metrics/__init__.py
+++ b/src/mozanalysis/metrics/__init__.py
@@ -114,12 +114,12 @@ class DataSource:
             raise ValueError
 
     def build_query(
-            self,
-            metric_list,
-            time_limits,
-            experiment_slug,
-            from_expr_dataset=None,
-            ):
+        self,
+        metric_list,
+        time_limits,
+        experiment_slug,
+        from_expr_dataset=None,
+    ):
         """Return a nearly-self contained SQL query.
 
         This query does not define ``enrollments`` but otherwise could

--- a/src/mozanalysis/metrics/fenix.py
+++ b/src/mozanalysis/metrics/fenix.py
@@ -15,7 +15,7 @@ baseline = DataSource(
             )""",
     client_id_column='client_info.client_id',
     experiments_column_type='glean',
-    default_dataset='org_mozilla_fenix',
+    default_dataset='org_mozilla_firefox',
 )
 
 
@@ -33,7 +33,7 @@ events = DataSource(
             )""",
     client_id_column='client_info.client_id',
     experiments_column_type='glean',
-    default_dataset='org_mozilla_fenix',
+    default_dataset='org_mozilla_firefox',
 )
 
 
@@ -47,7 +47,7 @@ metrics = DataSource(
             )""",
     client_id_column='client_info.client_id',
     experiments_column_type='glean',
-    default_dataset='org_mozilla_fenix',
+    default_dataset='org_mozilla_firefox',
 )
 
 

--- a/src/mozanalysis/metrics/fenix.py
+++ b/src/mozanalysis/metrics/fenix.py
@@ -11,10 +11,11 @@ baseline = DataSource(
                 SELECT
                     p.*,
                     DATE(p.submission_timestamp) AS submission_date
-                FROM `moz-fx-data-shared-prod.org_mozilla_fenix.baseline` p
+                FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
             )""",
     client_id_column='client_info.client_id',
     experiments_column_type='glean',
+    default_dataset='org_mozilla_fenix',
 )
 
 
@@ -26,12 +27,13 @@ events = DataSource(
                     DATE(p.submission_timestamp) AS submission_date,
                     event
                 FROM
-                    `moz-fx-data-shared-prod.org_mozilla_fenix.events` p
+                    `moz-fx-data-shared-prod.{dataset}.events` p
                 CROSS JOIN
                     UNNEST(p.events) AS event
             )""",
     client_id_column='client_info.client_id',
     experiments_column_type='glean',
+    default_dataset='org_mozilla_fenix',
 )
 
 
@@ -41,10 +43,11 @@ metrics = DataSource(
                 SELECT
                     p.*,
                     DATE(p.submission_timestamp) AS submission_date
-                FROM `moz-fx-data-shared-prod.org_mozilla_fenix.metrics` p
+                FROM `moz-fx-data-shared-prod.{dataset}.metrics` p
             )""",
     client_id_column='client_info.client_id',
     experiments_column_type='glean',
+    default_dataset='org_mozilla_fenix',
 )
 
 

--- a/src/mozanalysis/segments/__init__.py
+++ b/src/mozanalysis/segments/__init__.py
@@ -72,12 +72,12 @@ class SegmentDataSource:
         return self._from_expr.format(dataset=effective_dataset)
 
     def build_query(
-            self,
-            segment_list,
-            time_limits,
-            experiment_slug,
-            from_expr_dataset=None,
-            ):
+        self,
+        segment_list,
+        time_limits,
+        experiment_slug,
+        from_expr_dataset=None,
+    ):
         """Return a nearly self contained SQL query.
 
         The query takes a list of ``client_id``s from

--- a/src/mozanalysis/segments/__init__.py
+++ b/src/mozanalysis/segments/__init__.py
@@ -24,7 +24,10 @@ class SegmentDataSource:
         name (str): Name for the Data Source. Should be unique to avoid
             confusion.
         from_expr (str): FROM expression - often just a fully-qualified
-            table name. Sometimes a subquery.
+            table name. Sometimes a subquery. May contain the string
+            ``{dataset}`` which will be replaced with an app-specific
+            dataset for Glean apps. If the expression is templated
+            on dataset, default_dataset is mandatory.
         window_start (int, optional): See above.
         window_end (int, optional): See above.
         client_id_column (str, optional): Name of the column that
@@ -33,6 +36,10 @@ class SegmentDataSource:
         submission_date_column (str, optional): Name of the column
             that contains the submission date (as a date, not
             timestamp). Defaults to 'submission_date'.
+        default_dataset (str, optional): The value to use for
+            `{dataset}` in from_expr if a value is not provided
+            at runtime. Mandatory if from_expr contains a
+            `{dataset}` parameter.
     """
     name = attr.ib(validator=attr.validators.instance_of(str))
     from_expr = attr.ib(validator=attr.validators.instance_of(str))
@@ -40,8 +47,30 @@ class SegmentDataSource:
     window_end = attr.ib(default=0, type=int)
     client_id_column = attr.ib(default='client_id', type=str)
     submission_date_column = attr.ib(default='submission_date', type=str)
+    default_dataset = attr.ib(default=None, type=Optional[str])
 
-    def build_query(self, segment_list, time_limits, experiment_slug):
+    @default_dataset.validator
+    def _check_default_dataset_provided_if_needed(self, attribute, value):
+        self.from_expr_for(None)
+
+    def from_expr_for(self, dataset: Optional[str]) -> str:
+        effective_dataset = dataset or self.default_dataset
+        if effective_dataset is None:
+            try:
+                return self.from_expr.format()
+            except Exception as e:
+                raise ValueError(
+                    f"{self.name}: from_expr contains a dataset template but no value was provided."  # noqa:E501
+                ) from e
+        return self.from_expr.format(dataset=effective_dataset)
+
+    def build_query(
+            self,
+            segment_list,
+            time_limits,
+            experiment_slug,
+            from_expr_dataset=None,
+            ):
         """Return a nearly self contained SQL query.
 
         The query takes a list of ``client_id``s from
@@ -63,7 +92,7 @@ class SegmentDataSource:
         GROUP BY e.client_id""".format(
             client_id=self.client_id_column,
             submission_date=self.submission_date_column,
-            from_expr=self.from_expr,
+            from_expr=self.from_expr_for(from_expr_dataset),
             first_enrollment=time_limits.first_enrollment_date,
             last_enrollment=time_limits.last_enrollment_date,
             window_start=self.window_start,

--- a/src/mozanalysis/segments/__init__.py
+++ b/src/mozanalysis/segments/__init__.py
@@ -42,7 +42,7 @@ class SegmentDataSource:
             `{dataset}` parameter.
     """
     name = attr.ib(validator=attr.validators.instance_of(str))
-    from_expr = attr.ib(validator=attr.validators.instance_of(str))
+    _from_expr = attr.ib(validator=attr.validators.instance_of(str))
     window_start = attr.ib(default=0, type=int)
     window_end = attr.ib(default=0, type=int)
     client_id_column = attr.ib(default='client_id', type=str)
@@ -54,15 +54,22 @@ class SegmentDataSource:
         self.from_expr_for(None)
 
     def from_expr_for(self, dataset: Optional[str]) -> str:
+        """Expands the ``from_expr`` template for the given dataset.
+        If ``from_expr`` is not a template, returns ``from_expr``.
+
+        Args:
+            dataset (str or None): Dataset name to substitute
+                into the from expression.
+        """
         effective_dataset = dataset or self.default_dataset
         if effective_dataset is None:
             try:
-                return self.from_expr.format()
+                return self._from_expr.format()
             except Exception as e:
                 raise ValueError(
                     f"{self.name}: from_expr contains a dataset template but no value was provided."  # noqa:E501
                 ) from e
-        return self.from_expr.format(dataset=effective_dataset)
+        return self._from_expr.format(dataset=effective_dataset)
 
     def build_query(
             self,

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,7 +1,10 @@
 import pytest
 from cheap_lint import sql_lint
 
+from mozanalysis.metrics import Metric
 import mozanalysis.metrics.desktop as mad
+import mozanalysis.metrics.fenix
+from mozanalysis.segments import Segment, SegmentDataSource
 import mozanalysis.segments.desktop as msd
 from mozanalysis.experiment import TimeLimits, AnalysisWindow, Experiment
 
@@ -285,6 +288,44 @@ def test_segments_megaquery_not_detectably_malformed():
         time_limits=tl,
         enrollments_query_type='normandy',
     ).format(results_table='foo')
+
+    sql_lint(sql)
+
+
+def test_app_id_propagates():
+    exp = Experiment('slug', '2019-01-01', 8, app_id="my_cool_app")
+
+    tl = TimeLimits.for_ts(
+        first_enrollment_date='2019-01-01',
+        last_date_full_data='2019-03-01',
+        time_series_period='weekly',
+        num_dates_enrollment=8
+    )
+
+    sds = SegmentDataSource(
+        name="cool_data_source",
+        from_expr="`moz-fx-data-shared-prod`.{dataset}.cool_table",
+        default_dataset="org_mozilla_fenix",
+    )
+
+    segment = Segment(
+        name="cool_segment",
+        select_expr="COUNT(*)",
+        data_source=sds,
+    )
+
+    sql = exp.build_query_template(
+        metric_list=[
+            m for m in mozanalysis.metrics.fenix.__dict__.values()
+            if isinstance(m, Metric)
+        ],
+        segment_list=[segment],
+        time_limits=tl,
+        enrollments_query_type='fenix-fallback',
+    ).format(results_table='foo')
+
+    assert "org_mozilla_fenix" not in sql
+    assert "my_cool_app" in sql
 
     sql_lint(sql)
 

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -305,7 +305,7 @@ def test_app_id_propagates():
     sds = SegmentDataSource(
         name="cool_data_source",
         from_expr="`moz-fx-data-shared-prod`.{dataset}.cool_table",
-        default_dataset="org_mozilla_fenix",
+        default_dataset="org_mozilla_firefox",
     )
 
     segment = Segment(
@@ -324,7 +324,7 @@ def test_app_id_propagates():
         enrollments_query_type='fenix-fallback',
     ).format(results_table='foo')
 
-    assert "org_mozilla_fenix" not in sql
+    assert "org_mozilla_firefox" not in sql
     assert "my_cool_app" in sql
 
     sql_lint(sql)

--- a/tests/test_metric_libraries.py
+++ b/tests/test_metric_libraries.py
@@ -28,7 +28,7 @@ def test_sql_not_detectably_malformed(included_metrics, included_datasources):
         sql_lint(m.select_expr.format(experiment_slug='slug'))
 
     for _, ds in included_datasources:
-        sql_lint(ds.from_expr)
+        sql_lint(ds.from_expr_for(None))
 
 
 def test_consistency_of_metric_and_variable_names(included_metrics):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -30,3 +30,16 @@ def test_datasource_constructor_fails(name, from_expr, experiments_column_type, 
             from_expr=from_expr,
             experiments_column_type=experiments_column_type,
         )
+
+
+def test_complains_about_template_without_default():
+    with pytest.raises(ValueError):
+        DataSource(
+            name="foo",
+            from_expr="moz-fx-data-shared-prod.{dataset}.foo",
+        )
+    DataSource(
+        name="foo",
+        from_expr="moz-fx-data-shared-prod.{dataset}.foo",
+        default_dataset="dataset",
+    )

--- a/tests/test_segment_libraries.py
+++ b/tests/test_segment_libraries.py
@@ -27,7 +27,7 @@ def test_sql_not_detectably_malformed(included_segments, included_segment_dataso
         sql_lint(s.select_expr)
 
     for _name, sds in included_segment_datasources:
-        sql_lint(sds.from_expr)
+        sql_lint(sds.from_expr_for(None))
 
 
 def test_consistency_of_segment_and_variable_names(included_segments):
@@ -81,3 +81,16 @@ def test_segment_validates_not_metric_data_source():
 def test_included_segments_have_docs(included_segments):
     for name, segment in included_segments:
         assert segment.friendly_name and segment.description, name
+
+
+def test_complains_about_template_without_default():
+    with pytest.raises(ValueError):
+        msd.SegmentDataSource(
+            name="foo",
+            from_expr="moz-fx-data-shared-prod.{dataset}.foo",
+        )
+    msd.SegmentDataSource(
+        name="foo",
+        from_expr="moz-fx-data-shared-prod.{dataset}.foo",
+        default_dataset="dataset",
+    )


### PR DESCRIPTION
Different release channels of Glean apps have their data stored in different BigQuery datasets. This departs from the legacy telemetry practice on desktop, where data from all release channels end up in a single table.
This means that, although it's reasonable to talk about a set of metrics that are valid across the different Fenix release channels, the underlying DataSources need to be customized for each release channel.
I had once expected that this would be easy to do just by defining an alternate set of DataSources and rebasing the Metrics onto the new DataSources -- but the `events` data source is a good example of why this isn't as easy as I'd like. Data sources can be complex and it would be annoying to redefine them.

Instead, allow DataSources to be templated over dataset, and have the Experiment class forward some information from the client about which dataset the metrics should be based on.