### PR TITLE
Join enrollments more rigorously... and fix what was broken

### DIFF
--- a/src/mozanalysis/bq.py
+++ b/src/mozanalysis/bq.py
@@ -36,7 +36,7 @@ class BigQueryContext:
         self.project_id = project_id
         self.client = bigquery.Client(project=project_id)
 
-    def run_query_and_fetch(self, sql, results_table=None):
+    def run_query(self, sql, results_table=None):
         """Run a query and return the result.
 
         If ``results_table`` is provided, then save the results

--- a/src/mozanalysis/bq.py
+++ b/src/mozanalysis/bq.py
@@ -59,7 +59,9 @@ class BigQueryContext:
 
         except Conflict:
             print("Full results table already exists. Reusing", results_table)
-            return self.client.list_rows(results_table)
+            return self.client.list_rows(
+                self.fully_qualify_table_name(results_table)
+            )
 
     def fully_qualify_table_name(self, table_name):
         """Given a table name, return it fully qualified."""

--- a/src/mozanalysis/bq.py
+++ b/src/mozanalysis/bq.py
@@ -65,7 +65,7 @@ class BigQueryContext:
 
     def fully_qualify_table_name(self, table_name):
         """Given a table name, return it fully qualified."""
-        return "`{project_id}.{dataset_id}.{full_table_name}`".format(
+        return "{project_id}.{dataset_id}.{full_table_name}".format(
             project_id=self.project_id,
             dataset_id=self.dataset_id,
             full_table_name=table_name,

--- a/src/mozanalysis/bq.py
+++ b/src/mozanalysis/bq.py
@@ -67,7 +67,7 @@ class BigQueryContext:
             return full_res
 
         except Conflict:
-            print("Full results table already exists. Reusing", results_table)
+            print("Table already exists. Reusing", results_table)
             return self.client.list_rows(
                 self.fully_qualify_table_name(results_table)
             )

--- a/src/mozanalysis/bq.py
+++ b/src/mozanalysis/bq.py
@@ -38,9 +38,18 @@ class BigQueryContext:
 
     def run_query_and_fetch(self, sql, results_table=None):
         """Run a query and return the result.
+
         If ``results_table`` is provided, then save the results
         into there (or just query from there if it already exists).
         Returns a ``google.cloud.bigquery.table.RowIterator``
+
+        Args:
+            sql (str): A SQL query.
+            results_table (str, optional): A table name, not including
+                a project_id or dataset_id. The table name is used as a
+                cache key (if the table already exists, we ignore ``sql``
+                and return the table's contents), so it is wise for
+                ``results_table`` to include a hash of ``sql``.
         """
         if not results_table:
             return self.client.query(sql).result()

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -191,25 +191,27 @@ class Experiment:
             segment_list=segment_list,
         )
 
-        enrollments_table_name = sanitize_table_name_for_bq(
-            "_".join(
-                [
-                    last_date_full_data,
-                    "enrollments",
-                    self.experiment_slug,
-                    hash_ish(enrollments_sql),
-                ]
+        enrollments_table_name = bq_context.fully_qualify_table_name(
+            sanitize_table_name_for_bq(
+                "_".join(
+                    [
+                        last_date_full_data,
+                        "enrollments",
+                        self.experiment_slug,
+                        hash_ish(enrollments_sql),
+                    ]
+                )
             )
         )
 
-        enrollments_table = bq_context.run_query_and_fetch(
+        bq_context.run_query_and_fetch(
             enrollments_sql, enrollments_table_name
         )
 
         metrics_sql = self.build_metrics_query(
             metric_list=metric_list,
             time_limits=time_limits,
-            enrollments_table=enrollments_table,
+            enrollments_table=enrollments_table_name,
         )
 
         full_res_table_name = sanitize_table_name_for_bq(
@@ -296,25 +298,27 @@ class Experiment:
             segment_list=segment_list,
         )
 
-        enrollments_table_name = sanitize_table_name_for_bq(
-            "_".join(
-                [
-                    last_date_full_data,
-                    "enrollments",
-                    self.experiment_slug,
-                    hash_ish(enrollments_sql),
-                ]
+        enrollments_table_name = bq_context.fully_qualify_table_name(
+            sanitize_table_name_for_bq(
+                "_".join(
+                    [
+                        last_date_full_data,
+                        "enrollments",
+                        self.experiment_slug,
+                        hash_ish(enrollments_sql),
+                    ]
+                )
             )
         )
 
-        enrollments_table = bq_context.run_query_and_fetch(
+        bq_context.run_query_and_fetch(
             enrollments_sql, enrollments_table_name
         )
 
         metrics_sql = self.build_metrics_query(
             metric_list=metric_list,
             time_limits=time_limits,
-            enrollments_table=enrollments_table,
+            enrollments_table=enrollments_table_name,
         )
 
         full_res_table_name = sanitize_table_name_for_bq(

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -427,10 +427,14 @@ class Experiment:
         )
 
         return """
+        WITH enrollments AS (
+            SELECT *
+            FROM `{enrollments_table}`
+        )
         SELECT
             enrollments.*,
             {metrics_columns}
-        FROM `{enrollments_table}` AS enrollments
+        FROM enrollments
         {metrics_joins}
         """.format(
             metrics_columns=",\n        ".join(metrics_columns),

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -591,7 +591,7 @@ class Experiment:
             segments_joins.append(
                 """    LEFT JOIN (
         {query}
-        ) ds_{i} USING (client_id)
+        ) ds_{i} USING (client_id, branch)
                 """.format(
                     query=query_for_segments, i=i
                 )

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -527,7 +527,7 @@ class Experiment:
             metrics_joins.append(
                 """    LEFT JOIN (
         {query}
-        ) ds_{i} USING (client_id, analysis_window_start, analysis_window_end)
+        ) ds_{i} USING (client_id, branch, analysis_window_start, analysis_window_end)
                 """.format(
                     query=query_for_metrics, i=i
                 )

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -191,16 +191,14 @@ class Experiment:
             segment_list=segment_list,
         )
 
-        enrollments_table_name = bq_context.fully_qualify_table_name(
-            sanitize_table_name_for_bq(
-                "_".join(
-                    [
-                        last_date_full_data,
-                        "enrollments",
-                        self.experiment_slug,
-                        hash_ish(enrollments_sql),
-                    ]
-                )
+        enrollments_table_name = sanitize_table_name_for_bq(
+            "_".join(
+                [
+                    last_date_full_data,
+                    "enrollments",
+                    self.experiment_slug,
+                    hash_ish(enrollments_sql),
+                ]
             )
         )
 
@@ -211,7 +209,9 @@ class Experiment:
         metrics_sql = self.build_metrics_query(
             metric_list=metric_list,
             time_limits=time_limits,
-            enrollments_table=enrollments_table_name,
+            enrollments_table=bq_context.fully_qualify_table_name(
+                enrollments_table_name
+            ),
         )
 
         full_res_table_name = sanitize_table_name_for_bq(
@@ -298,16 +298,14 @@ class Experiment:
             segment_list=segment_list,
         )
 
-        enrollments_table_name = bq_context.fully_qualify_table_name(
-            sanitize_table_name_for_bq(
-                "_".join(
-                    [
-                        last_date_full_data,
-                        "enrollments",
-                        self.experiment_slug,
-                        hash_ish(enrollments_sql),
-                    ]
-                )
+        enrollments_table_name = sanitize_table_name_for_bq(
+            "_".join(
+                [
+                    last_date_full_data,
+                    "enrollments",
+                    self.experiment_slug,
+                    hash_ish(enrollments_sql),
+                ]
             )
         )
 
@@ -318,7 +316,9 @@ class Experiment:
         metrics_sql = self.build_metrics_query(
             metric_list=metric_list,
             time_limits=time_limits,
-            enrollments_table=enrollments_table_name,
+            enrollments_table=bq_context.fully_qualify_table_name(
+                enrollments_table_name
+            ),
         )
 
         full_res_table_name = sanitize_table_name_for_bq(

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -376,8 +376,6 @@ class Experiment:
                 {analysis_windows_query}
             ),
             raw_enrollments AS ({enrollments_query}),
-            -- TODO: enforce that raw_enrollments is uniquely keyed
-            -- by (client_id, branch)
             segmented_enrollments AS ({segments_query})
 
             SELECT
@@ -421,14 +419,10 @@ class Experiment:
         )
 
         return """
-        WITH enrollments AS (
-            SELECT *
-            FROM {enrollments_table}
-        )
         SELECT
             enrollments.*,
             {metrics_columns}
-        FROM enrollments
+        FROM `{enrollments_table}` AS enrollments
         {metrics_joins}
         """.format(
             metrics_columns=",\n        ".join(metrics_columns),

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -191,7 +191,20 @@ class Experiment:
             segment_list=segment_list,
         )
 
-        enrollments_table = bq_context.run_query(enrollments_sql)
+        enrollments_table_name = sanitize_table_name_for_bq(
+            "_".join(
+                [
+                    last_date_full_data,
+                    "enrollments",
+                    self.experiment_slug,
+                    hash_ish(enrollments_sql),
+                ]
+            )
+        )
+
+        enrollments_table = bq_context.run_query_and_fetch(
+            enrollments_sql, enrollments_table_name
+        )
 
         metrics_sql = self.build_metrics_query(
             metric_list=metric_list,

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -202,7 +202,7 @@ class Experiment:
             )
         )
 
-        bq_context.run_query_and_fetch(
+        bq_context.run_query(
             enrollments_sql, enrollments_table_name
         )
 
@@ -218,7 +218,7 @@ class Experiment:
             "_".join([last_date_full_data, self.experiment_slug, hash_ish(metrics_sql)])
         )
 
-        return bq_context.run_query_and_fetch(
+        return bq_context.run_query(
             metrics_sql, full_res_table_name
         ).to_dataframe()
 
@@ -309,7 +309,7 @@ class Experiment:
             )
         )
 
-        bq_context.run_query_and_fetch(
+        bq_context.run_query(
             enrollments_sql, enrollments_table_name
         )
 
@@ -325,7 +325,7 @@ class Experiment:
             "_".join([last_date_full_data, self.experiment_slug, hash_ish(metrics_sql)])
         )
 
-        bq_context.run_query_and_fetch(metrics_sql, full_res_table_name)
+        bq_context.run_query(metrics_sql, full_res_table_name)
 
         return TimeSeriesResult(
             fully_qualified_table_name=bq_context.fully_qualify_table_name(
@@ -890,7 +890,7 @@ class TimeSeriesResult:
                     "AnalysisWindow not found with start of {}".format(analysis_window)
                 )
 
-        return bq_context.run_query_and_fetch(
+        return bq_context.run_query(
             self._build_analysis_window_subset_query(analysis_window)
         ).to_dataframe()
 

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -146,6 +146,10 @@ class Experiment:
 
                     WITH raw_enrollments AS ({custom_enrollments_query})
 
+                N.B. this query's results must be uniquely keyed by
+                (client_id, branch), or else your results will be subtly
+                wrong.
+
             segment_list (list of mozanalysis.segment.Segment): The user
                 segments to study.
 
@@ -255,6 +259,10 @@ class Experiment:
                 in the main query::
 
                     WITH raw_enrollments AS ({custom_enrollments_query})
+
+                N.B. this query's results must be uniquely keyed by
+                (client_id, branch), or else your results will be subtly
+                wrong.
 
             segment_list (list of mozanalysis.segment.Segment): The user
                 segments to study.

--- a/src/mozanalysis/metrics/__init__.py
+++ b/src/mozanalysis/metrics/__init__.py
@@ -128,6 +128,7 @@ class DataSource:
         """
         return """SELECT
             e.client_id,
+            e.branch,
             e.analysis_window_start,
             e.analysis_window_end,
             {metrics}
@@ -139,7 +140,11 @@ class DataSource:
                     DATE_ADD(e.enrollment_date, interval e.analysis_window_start day)
                     AND DATE_ADD(e.enrollment_date, interval e.analysis_window_end day)
                 {ignore_pre_enroll_first_day}
-        GROUP BY e.client_id, e.analysis_window_start, e.analysis_window_end""".format(
+        GROUP BY
+            e.client_id,
+            e.branch,
+            e.analysis_window_start,
+            e.analysis_window_end""".format(
             client_id=self.client_id_column,
             submission_date=self.submission_date_column,
             from_expr=self.from_expr_for(from_expr_dataset),

--- a/src/mozanalysis/segments/__init__.py
+++ b/src/mozanalysis/segments/__init__.py
@@ -87,6 +87,7 @@ class SegmentDataSource:
         """
         return """SELECT
             e.client_id,
+            e.branch,
             {segments}
         FROM raw_enrollments e
             LEFT JOIN {from_expr} ds
@@ -97,7 +98,7 @@ class SegmentDataSource:
                 AND ds.{submission_date} BETWEEN
                     DATE_ADD(e.enrollment_date, interval {window_start} day)
                     AND DATE_ADD(e.enrollment_date, interval {window_end} day)
-        GROUP BY e.client_id""".format(
+        GROUP BY e.client_id, e.branch""".format(
             client_id=self.client_id_column,
             submission_date=self.submission_date_column,
             from_expr=self.from_expr_for(from_expr_dataset),


### PR DESCRIPTION
When I went to test in [a notebook](https://colab.research.google.com/drive/1x9wBQc7h80zpmymH-gs7seoP2Opxd-QG) the original change that fixes #117 and an equivalent bug with segments (commit 56d97bd), I found a bunch of apparently-broken functionality that led me on a merry end-of-year yak shave. Thanks @tdsmith for coming along for the ride!

In [the notebook](https://colab.research.google.com/drive/1x9wBQc7h80zpmymH-gs7seoP2Opxd-QG) I tested both `Experiment.get_time_series_data()` and `Experiment.get_single_window_data()`, and the results indicate that the bug is fixed (max 7 days of use in a week) and the methods both work and yield consistent results.

We should consider making the result _formats_ more consistent (hiding client_id and analysis window details from get_single_window_data), but that's an issue for another day.