### PR TITLE
Add metrics for disabling Pocket in New Tab.

### DIFF
--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -346,7 +346,7 @@ days_of_use = Metric(
 )
 
 #: Metric: Clicks to disable Pocket in New Tab
-pocket_rec_clicks = Metric(
+disable_pocket_clicks = Metric(
     name="disable_pocket_clicks",
     data_source=activity_stream_events,
     select_expr="""COUNTIF(
@@ -363,7 +363,7 @@ pocket_rec_clicks = Metric(
 )
 
 #: Metric: Clicks to disable Pocket sponsored content in New Tab
-pocket_spoc_clicks = Metric(
+disable_pocket_spocs_clicks = Metric(
     name="disable_pocket_spocs_clicks",
     data_source=activity_stream_events,
     select_expr="""COUNTIF(
@@ -374,7 +374,8 @@ pocket_spoc_clicks = Metric(
     friendly_name="Disabled Pocket sponsored content in New Tab",
     description=dedent(
         """\
-         Counts the number of clicks to disable Pocket sponsored content in New Tab made by each client.
+         Counts the number of clicks to disable Pocket sponsored content
+         in New Tab made by each client.
     """
     ),
 )

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -369,7 +369,7 @@ disable_pocket_spocs_clicks = Metric(
     select_expr="""COUNTIF(
                 event = 'PREF_CHANGED'
                 AND source = 'POCKET_SPOCS'
-                AND JSON_EXTRACT_SCALAR(value, '$.status') = false
+                AND JSON_EXTRACT_SCALAR(value, '$.status') = 'false'
             )""",
     friendly_name="Disabled Pocket sponsored content in New Tab",
     description=dedent(

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -344,3 +344,37 @@ days_of_use = Metric(
     friendly_name="Days of use",
     description="The number of days in the interval that each client sent a main ping.",
 )
+
+#: Metric: Clicks to disable Pocket in New Tab
+pocket_rec_clicks = Metric(
+    name="disable_pocket_clicks",
+    data_source=activity_stream_events,
+    select_expr="""COUNTIF(
+                event = 'PREF_CHANGED'
+                AND source = 'TOP_STORIES'
+                AND JSON_EXTRACT_SCALAR(value, '$.status') = 'false'
+            )""",
+    friendly_name="Disabled Pocket in New Tab",
+    description=dedent(
+        """\
+         Counts the number of clicks to disable Pocket in New Tab made by each client.
+    """
+    ),
+)
+
+#: Metric: Clicks to disable Pocket sponsored content in New Tab
+pocket_spoc_clicks = Metric(
+    name="disable_pocket_spocs_clicks",
+    data_source=activity_stream_events,
+    select_expr="""COUNTIF(
+                event = 'PREF_CHANGED'
+                AND source = 'POCKET_SPOCS'
+                AND JSON_EXTRACT_SCALAR(value, '$.status') = false
+            )""",
+    friendly_name="Disabled Pocket sponsored content in New Tab",
+    description=dedent(
+        """\
+         Counts the number of clicks to disable Pocket sponsored content in New Tab made by each client.
+    """
+    ),
+)


### PR DESCRIPTION
The telemetry to properly calculate the number of users un-ticking the options to show Pocket and/or Pocket sponsored stories in New Tab was added to FX86 🎉 