### PR TITLE
Rename master -> main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ workflows:
             - docs
           filters:
             branches:
-              only: master
+              only: main
   tagged-deploy:
     jobs:
       - deploy:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ and invoking:
 circleci build --job py37
 ```
 
-See [.circleci/config.yml](https://github.com/mozilla/mozanalysis/blob/master/.circleci/config.yml)
+See [.circleci/config.yml](https://github.com/mozilla/mozanalysis/blob/main/.circleci/config.yml)
 for the other configured job names (for running tests on different python versions).
 
 ## Deploying a new release

--- a/docs/api/segments/desktop.rst
+++ b/docs/api/segments/desktop.rst
@@ -1,4 +1,4 @@
 :mod:`mozanalysis.segments.desktop`
 -----------------------------------
 
-See the source for the included segments. Sphinx seems to be uncooperative displaying source code that does not define functions or classes - so view the latest source `on github <https://github.com/mozilla/mozanalysis/tree/master/src/mozanalysis/segments/desktop.py>`_.
+See the source for the included segments. Sphinx seems to be uncooperative displaying source code that does not define functions or classes - so view the latest source `on github <https://github.com/mozilla/mozanalysis/tree/main/src/mozanalysis/segments/desktop.py>`_.


### PR DESCRIPTION
Fixes https://github.com/mozilla/mozanalysis/issues/121

The repo branch has already been set to `main`, but `master` is referenced in a couple of places