### PR TITLE
Use concrete table for main data source

### DIFF
--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -50,7 +50,10 @@ normandy_events = DataSource(
     experiments_column_type="native",
 )
 
-#: DataSource: The telemetry.main ping table.
+#: DataSource: The telemetry_stable.main_v4 ping table.
+#: The main_v4 table is what backs the telemetry.main view.
+#: Referencing the table directly helps us stay under the BigQuery
+#: query complexity budget.
 main = DataSource(
     name="main",
     from_expr="""(

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -58,7 +58,7 @@ main = DataSource(
                     *,
                     DATE(submission_timestamp) AS submission_date,
                     environment.experiments
-                FROM `moz-fx-data-shared-prod`.telemetry.main
+                FROM `moz-fx-data-shared-prod`.telemetry_stable.main_v4
             )""",
     experiments_column_type="native",
 )


### PR DESCRIPTION
Uses the `telemetry_stable.main_v4` table instead of the `telemetry.main` compatibility view for the `main` data source.

This is intended to reduce the complexity of the analysis query in order to stay within Google's complexity budget.

We expect that this is compatible with all existing metrics because the view doesn't make very many changes, although the changes it does make are fairly complex.