### PR TITLE
Pull in configurations from jetstream-config

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -19,7 +19,6 @@ We take the per-notebook daily trudge::
 
 Then we import the necessary classes for getting the data, and for analysing the data, and for interacting with BigQuery::
 
-    import mozanalysis.metrics.desktop as mmd
     import mozanalysis.bayesian_stats.binary as mabsbin
     from mozanalysis.experiment import Experiment
     from mozanalysis.bq import BigQueryContext
@@ -45,7 +44,8 @@ We start by instantiating our :class:`mozanalysis.experiment.Experiment` object:
     exp = Experiment(
         experiment_slug='pref-fingerprinting-protections-retention-study-release-70',
         start_date='2019-10-29',
-        num_dates_enrollment=8
+        num_dates_enrollment=8,
+        app_name="firefox_desktop"
     )
 
 ``start_date`` is the ``submission_date`` of the first enrollment (``submission_date`` is in UTC). If you intended to study one week's worth of enrollments, then set ``num_dates_enrollment=8``: Normandy experiments typically go live in the evening UTC-time, so 8 days of data is a better approximation than 7.
@@ -65,16 +65,18 @@ A metric must be computed over some `analysis window`, a period of time defined 
     ts_res = exp.get_time_series_data(
         bq_context=bq_context,
         metric_list=[
-            mmd.active_hours,
-            mmd.uri_count,
-            mmd.ad_clicks,
-            mmd.search_count,
+            "active_hours",
+            "uri_count",
+            "ad_clicks",
+            "search_count",
         ],
         last_date_full_data='2019-11-28',
         time_series_period='weekly'
     )
 
 The first two arguments to :meth:`mozanalysis.experiment.Experiment.get_time_series_data()` should be clear by this point. ``last_date_full_data`` is the last date for which we want to use data. For a currently-running experiment, it would typically be yesterday's date (we have incomplete data for incomplete days!).
+
+Metrics are pulled in from [jetstream-config](https://github.com/mozilla/jetstream-config) based on the provided metric slugs.
 
 ``time_series_period`` can be ``'daily'``, ``'weekly'`` or ``'28_day'``. A ``'weekly'`` time series neatly sidesteps/masks weekly seasonality issues: most of the experiment subjects will enroll within a day of the experiment launching - typically a Tuesday, leading to ``'daily'`` time series reflecting a non-uniform convolution of the metrics' weekly seasonalities with the uneven enrollment numbers across the week.
 
@@ -113,7 +115,7 @@ And we can do the usual pandas DataFrame things - e.g. calculate the mean active
     Cohort_3    6.468948
     Name: active_hours, dtype: float64
 
-Suppose we want to see whether the user had any active hours in their second week in the experiment. This information can be calculated from the ``mmd.active_hours`` metric - we add this as a column to the results pandas DataFrame, then use :mod:`mozanalysis.bayesian_stats.binary` to analyse this data::
+Suppose we want to see whether the user had any active hours in their second week in the experiment. This information can be calculated from the ``active_hours`` metric - we add this as a column to the results pandas DataFrame, then use :mod:`mozanalysis.bayesian_stats.binary` to analyse this data::
 
     res[7]['active_hours_gt_0'] = res[7]['active_hours'] > 0
 
@@ -218,7 +220,6 @@ Condensing the above example for simpler copying and pasting::
     auth.authenticate_user()
     print('Authenticated')
 
-    import mozanalysis.metrics.desktop as mmd
     import mozanalysis.bayesian_stats.binary as mabsbin
     from mozanalysis.experiment import Experiment
     from mozanalysis.bq import BigQueryContext
@@ -228,10 +229,10 @@ Condensing the above example for simpler copying and pasting::
     ts_res = exp.get_time_series_data(
         bq_context=bq_context,
         metric_list=[
-            mmd.active_hours,
-            mmd.uri_count,
-            mmd.ad_clicks,
-            mmd.search_count,
+            "active_hours",
+            "uri_count",
+            "ad_clicks",
+            "search_count",
         ],
         last_date_full_data='2019-11-28',
         time_series_period='weekly'
@@ -251,7 +252,6 @@ If we're only interested in users' (say) second week in the experiment, then we 
     auth.authenticate_user()
     print('Authenticated')
 
-    import mozanalysis.metrics.desktop as mmd
     import mozanalysis.bayesian_stats.binary as mabsbin
     from mozanalysis.experiment import Experiment
     from mozanalysis.bq import BigQueryContext
@@ -261,7 +261,7 @@ If we're only interested in users' (say) second week in the experiment, then we 
     res = exp.get_single_window_data(
         bq_context=bq_context,
         metric_list=[
-            mmd.active_hours,
+            "active_hours",
         ],
         last_date_full_data='2019-01-07',
         analysis_start_days=7,

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     package_dir={"": "src"},
     install_requires=[
         "attrs",
-        "jetstream-config-parser",
+        "mozilla-jetstream-config-parser",
         "numpy",
         "pandas",
         "pyarrow",

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     package_dir={"": "src"},
     install_requires=[
         "attrs",
+        "jetstream-config-parser",
         "numpy",
         "pandas",
         "pyarrow",

--- a/src/mozanalysis/__init__.py
+++ b/src/mozanalysis/__init__.py
@@ -20,3 +20,26 @@ for root, subdirs, files in os.walk(basedir):
     if os.path.basename(root) in __all__:
         module_files = [os.path.basename(root) + "." + f for f in module_files]
     __all__ += module_files
+
+# lookup app_name via app_id
+# used for backwards compatibility
+APPS = {
+    "firefox_desktop": {
+        "firefox_desktop"
+    },
+    "fenix": {
+        "org_mozilla_fenix"
+    },
+    "focus_android": {
+        "org_mozilla_focus"
+    },
+    "firefox_ios": {
+        "org_mozilla_ios_FirefoxBeta"
+    },
+    "focus_ios": {
+        "org_mozilla_ios_Focus"
+    },
+    "klar_ios": {
+        "org_mozilla_ios_Klar"
+    }
+}

--- a/src/mozanalysis/__init__.py
+++ b/src/mozanalysis/__init__.py
@@ -24,22 +24,10 @@ for root, subdirs, files in os.walk(basedir):
 # lookup app_name via app_id
 # used for backwards compatibility
 APPS = {
-    "firefox_desktop": {
-        "firefox_desktop"
-    },
-    "fenix": {
-        "org_mozilla_fenix"
-    },
-    "focus_android": {
-        "org_mozilla_focus"
-    },
-    "firefox_ios": {
-        "org_mozilla_ios_FirefoxBeta"
-    },
-    "focus_ios": {
-        "org_mozilla_ios_Focus"
-    },
-    "klar_ios": {
-        "org_mozilla_ios_Klar"
-    }
+    "firefox_desktop": {"firefox_desktop"},
+    "fenix": {"org_mozilla_fenix"},
+    "focus_android": {"org_mozilla_focus"},
+    "firefox_ios": {"org_mozilla_ios_FirefoxBeta"},
+    "focus_ios": {"org_mozilla_ios_Focus"},
+    "klar_ios": {"org_mozilla_ios_Klar"},
 }

--- a/src/mozanalysis/bayesian_stats/bayesian_bootstrap.py
+++ b/src/mozanalysis/bayesian_stats/bayesian_bootstrap.py
@@ -284,7 +284,7 @@ def get_bootstrap_samples(
             no. 1, 130--134. https://dx.doi.org/10.1214/aos/1176345338
     """
     if not type(data) == np.ndarray:
-        data = np.array(data.to_numpy(dtype='float', na_value=np.nan))
+        data = np.array(data.to_numpy(dtype="float", na_value=np.nan))
 
     if np.isnan(data).any():
         raise ValueError("'data' contains null values")

--- a/src/mozanalysis/bq.py
+++ b/src/mozanalysis/bq.py
@@ -1,10 +1,13 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import logging
 import re
 
 from google.api_core.exceptions import Conflict
 from google.cloud import bigquery
+
+logger = logging.getLogger(__name__)
 
 
 def sanitize_table_name_for_bq(table_name):
@@ -63,11 +66,11 @@ class BigQueryContext:
                     )
                 ),
             ).result()
-            print("Saved into", results_table)
+            logger.info("Saved into", results_table)
             return full_res
 
         except Conflict:
-            print("Table already exists. Reusing", results_table)
+            logger.info("Table already exists. Reusing", results_table)
             return self.client.list_rows(self.fully_qualify_table_name(results_table))
 
     def fully_qualify_table_name(self, table_name):

--- a/src/mozanalysis/config.py
+++ b/src/mozanalysis/config.py
@@ -2,15 +2,22 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from asyncio import windows_events
 from typing import Optional
-import attr
-from pytest import Config
 
+import attr
 from jetstream_config_parser.config import ConfigCollection
 
 from mozanalysis.metrics import DataSource, Metric
+from mozanalysis.segments import Segment, SegmentDataSource
+
 
 class _ConfigLoader:
+    """
+    Loads config files from an external repository.
+
+    Config objects are converted into mozanalysis native types.
+    """
     config_collection: Optional[ConfigCollection] = attr.ib(None)
 
     @property
@@ -33,7 +40,7 @@ class _ConfigLoader:
             select_expr=self.configs.get_env().from_string(metric_definition.select_expression).render(),
             friendly_name=metric_definition.friendly_name,
             description=metric_definition.friendly_name,
-            data_source=self.configs.get_data_source(metric_definition.data_source.name, app_name),
+            data_source=self.get_data_source(metric_definition.data_source.name, app_name),
             bigger_is_better=metric_definition.bigger_is_better
         )
 
@@ -51,7 +58,32 @@ class _ConfigLoader:
             default_dataset=data_source_definition.default_dataset
         )
 
-    def get_segment():
-        pass
+    def get_segment(self, segment_slug: str, app_name: str):
+        segment_definition = self.configs.get_segment_definition(segment_slug, app_name)
+        if segment_definition is None:
+            raise Exception(f"Could not find definition for segment {segment_slug}")
+
+        return Segment(
+            name=segment_definition.name,
+            data_source=self.get_segment_data_source(segment_definition.data_source.name, app_name),
+            select_expr=segment_definition.select_expression,
+            friendly_name=segment_definition.friendly_name,
+            description=segment_definition.description
+        )
+
+    def get_segment_data_source(self, data_source_slug: str, app_name: str):
+        data_source_definition = self.configs.get_segment_data_source_definition(data_source_slug, app_name)
+        if data_source_definition is None:
+            raise Exception(f"Could not find definition for segment data source {data_source_slug}")
+
+        return SegmentDataSource(
+            name=data_source_definition.name,
+            from_expr=data_source_definition.from_expression,
+            window_start=data_source_definition.window_start,
+            windows_end=data_source_definition.window_end,
+            client_id_column=data_source_definition.client_id_column,
+            submission_date_column=data_source_definition.submission_date_column,
+            default_dataset=data_source_definition.default_dataset
+        )
 
 ConfigLoader = _ConfigLoader()

--- a/src/mozanalysis/config.py
+++ b/src/mozanalysis/config.py
@@ -4,11 +4,7 @@
 
 from typing import Optional
 
-import attr
 from jetstream_config_parser.config import ConfigCollection
-
-from mozanalysis.metrics import DataSource, Metric
-from mozanalysis.segments import Segment, SegmentDataSource
 
 
 class _ConfigLoader:
@@ -17,11 +13,13 @@ class _ConfigLoader:
 
     Config objects are converted into mozanalysis native types.
     """
-    config_collection: Optional[ConfigCollection] = attr.ib(None)
+
+    config_collection: Optional[ConfigCollection] = None
 
     @property
     def configs(self) -> ConfigCollection:
-        if configs := getattr(self, "_configs", None):
+        configs = getattr(self, "_configs", None)
+        if configs:
             return configs
 
         if self.config_collection is None:
@@ -29,60 +27,85 @@ class _ConfigLoader:
         self._configs = self.config_collection
         return self._configs
 
-    def get_metric(self, metric_slug: str, app_name: str) -> Metric:
+    def get_metric(self, metric_slug: str, app_name: str):
+        from mozanalysis.metrics import Metric
+
         metric_definition = self.configs.get_metric_definition(metric_slug, app_name)
         if metric_definition is None:
             raise Exception(f"Could not find definition for metric {metric_slug}")
 
         return Metric(
             name=metric_definition.name,
-            select_expr=self.configs.get_env().from_string(metric_definition.select_expression).render(),
+            select_expr=self.configs.get_env()
+            .from_string(metric_definition.select_expression)
+            .render(),
             friendly_name=metric_definition.friendly_name,
             description=metric_definition.friendly_name,
-            data_source=self.get_data_source(metric_definition.data_source.name, app_name),
-            bigger_is_better=metric_definition.bigger_is_better
+            data_source=self.get_data_source(
+                metric_definition.data_source.name, app_name
+            ),
+            bigger_is_better=metric_definition.bigger_is_better,
         )
 
-    def get_data_source(self, data_source_slug: str, app_name: str) -> DataSource:
-        data_source_definition = self.configs.get_data_source_definition(data_source_slug, app_name)
+    def get_data_source(self, data_source_slug: str, app_name: str):
+        from mozanalysis.metrics import DataSource
+
+        data_source_definition = self.configs.get_data_source_definition(
+            data_source_slug, app_name
+        )
         if data_source_definition is None:
-            raise Exception(f"Could not find definition for data source {data_source_slug}")
+            raise Exception(
+                f"Could not find definition for data source {data_source_slug}"
+            )
 
         return DataSource(
             name=data_source_definition.name,
             from_expr=data_source_definition.from_expression,
             client_id_column=data_source_definition.client_id_column,
             submission_date_column=data_source_definition.submission_date_column,
-            experiments_column_type=data_source_definition.experiments_column_type,
-            default_dataset=data_source_definition.default_dataset
+            experiments_column_type=None
+            if data_source_definition.experiments_column_type == "none"
+            else data_source_definition.experiments_column_type,
+            default_dataset=data_source_definition.default_dataset,
         )
 
     def get_segment(self, segment_slug: str, app_name: str):
+        from mozanalysis.segments import Segment
+
         segment_definition = self.configs.get_segment_definition(segment_slug, app_name)
         if segment_definition is None:
             raise Exception(f"Could not find definition for segment {segment_slug}")
 
         return Segment(
             name=segment_definition.name,
-            data_source=self.get_segment_data_source(segment_definition.data_source.name, app_name),
+            data_source=self.get_segment_data_source(
+                segment_definition.data_source.name, app_name
+            ),
             select_expr=segment_definition.select_expression,
             friendly_name=segment_definition.friendly_name,
-            description=segment_definition.description
+            description=segment_definition.description,
         )
 
     def get_segment_data_source(self, data_source_slug: str, app_name: str):
-        data_source_definition = self.configs.get_segment_data_source_definition(data_source_slug, app_name)
+        from mozanalysis.segments import SegmentDataSource
+
+        data_source_definition = self.configs.get_segment_data_source_definition(
+            data_source_slug, app_name
+        )
         if data_source_definition is None:
-            raise Exception(f"Could not find definition for segment data source {data_source_slug}")
+            raise Exception(
+                f"Could not find definition for segment data source {data_source_slug}"
+            )
 
         return SegmentDataSource(
             name=data_source_definition.name,
             from_expr=data_source_definition.from_expression,
             window_start=data_source_definition.window_start,
-            windows_end=data_source_definition.window_end,
+            window_end=data_source_definition.window_end,
             client_id_column=data_source_definition.client_id_column,
             submission_date_column=data_source_definition.submission_date_column,
-            default_dataset=data_source_definition.default_dataset
+            default_dataset=data_source_definition.default_dataset,
         )
+
 
 ConfigLoader = _ConfigLoader()

--- a/src/mozanalysis/config.py
+++ b/src/mozanalysis/config.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from asyncio import windows_events
 from typing import Optional
 
 import attr

--- a/src/mozanalysis/config.py
+++ b/src/mozanalysis/config.py
@@ -1,0 +1,57 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from typing import Optional
+import attr
+from pytest import Config
+
+from jetstream_config_parser.config import ConfigCollection
+
+from mozanalysis.metrics import DataSource, Metric
+
+class _ConfigLoader:
+    config_collection: Optional[ConfigCollection] = attr.ib(None)
+
+    @property
+    def configs(self) -> ConfigCollection:
+        if configs := getattr(self, "_configs", None):
+            return configs
+
+        if self.config_collection is None:
+            self.config_collection = ConfigCollection.from_github_repo()
+        self._configs = self.config_collection
+        return self._configs
+
+    def get_metric(self, metric_slug: str, app_name: str) -> Metric:
+        metric_definition = self.configs.get_metric_definition(metric_slug, app_name)
+        if metric_definition is None:
+            raise Exception(f"Could not find definition for metric {metric_slug}")
+
+        return Metric(
+            name=metric_definition.name,
+            select_expr=self.configs.get_env().from_string(metric_definition.select_expression).render(),
+            friendly_name=metric_definition.friendly_name,
+            description=metric_definition.friendly_name,
+            data_source=self.configs.get_data_source(metric_definition.data_source.name, app_name),
+            bigger_is_better=metric_definition.bigger_is_better
+        )
+
+    def get_data_source(self, data_source_slug: str, app_name: str) -> DataSource:
+        data_source_definition = self.configs.get_data_source_definition(data_source_slug, app_name)
+        if data_source_definition is None:
+            raise Exception(f"Could not find definition for data source {data_source_slug}")
+
+        return DataSource(
+            name=data_source_definition.name,
+            from_expr=data_source_definition.from_expression,
+            client_id_column=data_source_definition.client_id_column,
+            submission_date_column=data_source_definition.submission_date_column,
+            experiments_column_type=data_source_definition.experiments_column_type,
+            default_dataset=data_source_definition.default_dataset
+        )
+
+    def get_segment():
+        pass
+
+ConfigLoader = _ConfigLoader()

--- a/src/mozanalysis/config.py
+++ b/src/mozanalysis/config.py
@@ -81,7 +81,9 @@ class _ConfigLoader:
             data_source=self.get_segment_data_source(
                 segment_definition.data_source.name, app_name
             ),
-            select_expr=segment_definition.select_expression,
+            select_expr=self.configs.get_env()
+            .from_string(segment_definition.select_expression)
+            .render(),
             friendly_name=segment_definition.friendly_name,
             description=segment_definition.description,
         )

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -4,11 +4,14 @@
 from enum import Enum
 
 import attr
+import logging
 
 from mozanalysis import APPS
 from mozanalysis.bq import sanitize_table_name_for_bq
 from mozanalysis.config import ConfigLoader
 from mozanalysis.utils import add_days, date_sub, hash_ish
+
+logger = logging.getLogger(__name__)
 
 
 class AnalysisBasis(Enum):
@@ -128,7 +131,7 @@ class Experiment:
         a pre-defined list. (this is deprecated)
         """
         if self.app_name is None:
-            print(
+            logger.warning(
                 "Experiment without `app_name` is deprecated. "
                 + "Please specify an app_name explicitly"
             )

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -5,7 +5,9 @@ from enum import Enum
 
 import attr
 
+from mozanalysis import APPS
 from mozanalysis.bq import sanitize_table_name_for_bq
+from mozanalysis.config import ConfigLoader
 from mozanalysis.utils import add_days, date_sub, hash_ish
 
 
@@ -96,6 +98,7 @@ class Experiment:
             before UTC midnight.
         app_id (str, optional): For a Glean app, the name of the BigQuery
             dataset derived from its app ID, like `org_mozilla_firefox`.
+        app_name (str, optional): The Glean app name, like `fenix`.
 
     Attributes:
         experiment_slug (str): Name of the study, used to identify
@@ -115,6 +118,22 @@ class Experiment:
     start_date = attr.ib()
     num_dates_enrollment = attr.ib(default=None)
     app_id = attr.ib(default=None)
+    app_name = attr.ib(default=None)
+
+    def get_app_name(self) -> str:
+        """
+        Determine the correct app name.
+        
+        If no explicit app name has been passed into Experiment, lookup app name from
+        a pre-defined list. (this is deprecated)
+        """
+        if self.app_name is None:
+            print("Experiment without `app_name` is deprecated. "+"Please specify an app_name explicitly")
+            app_name = next(key for key, value in APPS.items() if self.app_id in value)
+            if app_name is None:
+                raise Exception(f"No app name for app_id {self.app_id}")
+        return self.app_name
+
 
     def get_single_window_data(
         self,
@@ -137,7 +156,7 @@ class Experiment:
 
         Args:
             bq_context (BigQueryContext): BigQuery configuration and client.
-            metric_list (list of mozanalysis.metric.Metric): The metrics
+            metric_list (list of mozanalysis.metric.Metric or str): The metrics
                 to analyze.
             last_date_full_data (str): The most recent date for which we
                 have complete data, e.g. '2019-03-22'. If you want to ignore
@@ -175,7 +194,7 @@ class Experiment:
                 client has been exposed to the experiment. If not provided,
                 the exposure will be determined based on Normandy exposure events
                 for desktop and Nimbus exposure events for Fenix and iOS.
-            segment_list (list of mozanalysis.segment.Segment): The user
+            segment_list (list of mozanalysis.segment.Segment or str): The user
                 segments to study.
 
         Returns:
@@ -412,7 +431,7 @@ class Experiment:
             exposure_signal (ExposureSignal): Optional signal definition of when a
                 client has been exposed to the experiment
 
-            segment_list (list of mozanalysis.segment.Segment): The user
+            segment_list (list of mozanalysis.segment.Segment or str): The user
                 segments to study.
 
         Returns:
@@ -471,7 +490,7 @@ class Experiment:
         be computed for these clients.
 
         Args:
-            metric_list (list of mozanalysis.metric.Metric):
+            metric_list (list of mozanalysis.metric.Metric or str):
                 The metrics to analyze.
             time_limits (TimeLimits): An object describing the
                 interval(s) to query
@@ -772,7 +791,14 @@ class Experiment:
         exposure_signal=None,
     ):
         """Return lists of SQL fragments corresponding to metrics."""
-        ds_metrics = self._partition_by_data_source(metric_list)
+        metrics = []
+        for metric in metric_list:
+            if isinstance(metric, str):
+                metrics.append(ConfigLoader.get_metric(metric, self.get_app_name()))
+            else:
+                metrics.append(metric)
+        
+        ds_metrics = self._partition_by_data_source(metrics)
         ds_metrics = {
             ds: metrics + ds.get_sanity_metrics(self.experiment_slug)
             for ds, metrics in ds_metrics.items()
@@ -845,7 +871,16 @@ class Experiment:
 
     def _build_segments_query_bits(self, segment_list, time_limits):
         """Return lists of SQL fragments corresponding to segments."""
-        ds_segments = self._partition_by_data_source(segment_list)
+
+        # resolve segment slugs
+        segments = []
+        for segment in segment_list:
+            if isinstance(segment, str):
+                segments.append(ConfigLoader.get_segment(segment, self.get_app_name()))
+            else:
+                segments.append(segment)
+
+        ds_segments = self._partition_by_data_source(segments)
 
         segments_columns = []
         segments_joins = []

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -120,20 +120,22 @@ class Experiment:
     app_id = attr.ib(default=None)
     app_name = attr.ib(default=None)
 
-    def get_app_name(self) -> str:
+    def get_app_name(self):
         """
         Determine the correct app name.
-        
+
         If no explicit app name has been passed into Experiment, lookup app name from
         a pre-defined list. (this is deprecated)
         """
         if self.app_name is None:
-            print("Experiment without `app_name` is deprecated. "+"Please specify an app_name explicitly")
+            print(
+                "Experiment without `app_name` is deprecated. "
+                + "Please specify an app_name explicitly"
+            )
             app_name = next(key for key, value in APPS.items() if self.app_id in value)
             if app_name is None:
                 raise Exception(f"No app name for app_id {self.app_id}")
         return self.app_name
-
 
     def get_single_window_data(
         self,
@@ -797,7 +799,7 @@ class Experiment:
                 metrics.append(ConfigLoader.get_metric(metric, self.get_app_name()))
             else:
                 metrics.append(metric)
-        
+
         ds_metrics = self._partition_by_data_source(metrics)
         ds_metrics = {
             ds: metrics + ds.get_sanity_metrics(self.experiment_slug)

--- a/src/mozanalysis/frequentist_stats/bootstrap.py
+++ b/src/mozanalysis/frequentist_stats/bootstrap.py
@@ -184,7 +184,7 @@ def get_bootstrap_samples(
               with columns set to the dict keys.
     """
     if not type(data) == np.ndarray:
-        data = np.array(data.to_numpy(dtype='float', na_value=np.nan))
+        data = np.array(data.to_numpy(dtype="float", na_value=np.nan))
 
     if np.isnan(data).any():
         raise ValueError("'data' contains null values")

--- a/src/mozanalysis/metrics/__init__.py
+++ b/src/mozanalysis/metrics/__init__.py
@@ -4,8 +4,11 @@
 from typing import Optional
 
 import attr
+import logging
 
 from mozanalysis.experiment import AnalysisBasis
+
+logger = logging.getLogger(__name__)
 
 
 @attr.s(frozen=True, slots=True)
@@ -282,19 +285,19 @@ class Metric:
 
 def agg_sum(select_expr):
     """Return a SQL fragment for the sum over the data, with 0-filled nulls."""
-    print("The use of mozanalysis.metrics.agg_sum() is deprecated")
+    logger.warning("The use of mozanalysis.metrics.agg_sum() is deprecated")
     return "COALESCE(SUM({}), 0)".format(select_expr)
 
 
 def agg_any(select_expr):
     """Return the logical OR, with FALSE-filled nulls."""
-    print("The use of mozanalysis.metrics.agg_any() is deprecated")
+    logger.warning("The use of mozanalysis.metrics.agg_any() is deprecated")
     return "COALESCE(LOGICAL_OR({}), FALSE)".format(select_expr)
 
 
 def agg_histogram_mean(select_expr):
     """Produces an expression for the mean of an unparsed histogram."""
-    print("The use of mozanalysis.metrics.agg_histogram_mean() is deprecated")
+    logger.warning("The use of mozanalysis.metrics.agg_histogram_mean() is deprecated")
     return f"""SAFE_DIVIDE(
                 SUM(CAST(JSON_EXTRACT_SCALAR({select_expr}, "$.sum") AS int64)),
                 SUM((SELECT SUM(value) FROM UNNEST(mozfun.hist.extract({select_expr}).values)))

--- a/src/mozanalysis/metrics/__init__.py
+++ b/src/mozanalysis/metrics/__init__.py
@@ -282,16 +282,19 @@ class Metric:
 
 def agg_sum(select_expr):
     """Return a SQL fragment for the sum over the data, with 0-filled nulls."""
+    print("The use of mozanalysis.metrics.agg_sum() is deprecated")
     return "COALESCE(SUM({}), 0)".format(select_expr)
 
 
 def agg_any(select_expr):
     """Return the logical OR, with FALSE-filled nulls."""
+    print("The use of mozanalysis.metrics.agg_any() is deprecated")
     return "COALESCE(LOGICAL_OR({}), FALSE)".format(select_expr)
 
 
 def agg_histogram_mean(select_expr):
     """Produces an expression for the mean of an unparsed histogram."""
+    print("The use of mozanalysis.metrics.agg_histogram_mean() is deprecated")
     return f"""SAFE_DIVIDE(
                 SUM(CAST(JSON_EXTRACT_SCALAR({select_expr}, "$.sum") AS int64)),
                 SUM((SELECT SUM(value) FROM UNNEST(mozfun.hist.extract({select_expr}).values)))

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# These metric definitions are deprected.
+# These metric definitions are deprecated.
 # Instead use the metric slug to reference metrics defined
 # in https://github.com/mozilla/jetstream-config
 
@@ -14,9 +14,7 @@ search_clients_engines_sources_daily = ConfigLoader.get_data_source(
     "search_clients_engines_sources_daily", "firefox_desktop"
 )
 
-search_clients_daily = ConfigLoader.get_data_source(
-    "search_clients_engines_sources_daily", "firefox_desktop"
-)
+search_clients_daily = search_clients_engines_sources_daily
 
 main_summary = ConfigLoader.get_data_source("main_summary", "firefox_desktop")
 

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -2,6 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# These metric definitions are deprected.
+# Instead use the metric slug to reference metrics defined
+# in https://github.com/mozilla/jetstream-config
+
 from mozanalysis.config import ConfigLoader
 
 clients_daily = ConfigLoader.get_data_source("clients_daily", "firefox_desktop")

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -6,9 +6,13 @@ from mozanalysis.config import ConfigLoader
 
 clients_daily = ConfigLoader.get_data_source("clients_daily", "firefox_desktop")
 
-search_clients_engines_sources_daily = ConfigLoader.get_data_source("search_clients_engines_sources_daily", "firefox_desktop")
+search_clients_engines_sources_daily = ConfigLoader.get_data_source(
+    "search_clients_engines_sources_daily", "firefox_desktop"
+)
 
-search_clients_daily = ConfigLoader.get_data_source("search_clients_engines_sources_daily", "firefox_desktop")
+search_clients_daily = ConfigLoader.get_data_source(
+    "search_clients_engines_sources_daily", "firefox_desktop"
+)
 
 main_summary = ConfigLoader.get_data_source("main_summary", "firefox_desktop")
 
@@ -22,7 +26,9 @@ crash = ConfigLoader.get_data_source("crash", "firefox_desktop")
 
 cfr = ConfigLoader.get_data_source("cfr", "firefox_desktop")
 
-activity_stream_events = ConfigLoader.get_data_source("activity_stream_events", "firefox_desktop")
+activity_stream_events = ConfigLoader.get_data_source(
+    "activity_stream_events", "firefox_desktop"
+)
 
 
 active_hours = ConfigLoader.get_metric("active_hours", "firefox_desktop")
@@ -33,19 +39,25 @@ search_count = ConfigLoader.get_metric("search_count", "firefox_desktop")
 
 tagged_search_count = ConfigLoader.get_metric("tagged_search_count", "firefox_desktop")
 
-tagged_follow_on_search_count = ConfigLoader.get_metric("tagged_follow_on_search_count", "firefox_desktop")
+tagged_follow_on_search_count = ConfigLoader.get_metric(
+    "tagged_follow_on_search_count", "firefox_desktop"
+)
 
 ad_clicks = ConfigLoader.get_metric("ad_clicks", "firefox_desktop")
 
 searches_with_ads = ConfigLoader.get_metric("searches_with_ads", "firefox_desktop")
 
-organic_search_count = ConfigLoader.get_metric("organic_search_count", "firefox_desktop")
+organic_search_count = ConfigLoader.get_metric(
+    "organic_search_count", "firefox_desktop"
+)
 
 unenroll = ConfigLoader.get_metric("unenroll", "firefox_desktop")
 
 view_about_logins = ConfigLoader.get_metric("view_about_logins", "firefox_desktop")
 
-view_about_protections = ConfigLoader.get_metric("view_about_protections", "firefox_desktop")
+view_about_protections = ConfigLoader.get_metric(
+    "view_about_protections", "firefox_desktop"
+)
 
 connect_fxa = ConfigLoader.get_metric("connect_fxa", "firefox_desktop")
 
@@ -55,8 +67,14 @@ pocket_spoc_clicks = ConfigLoader.get_metric("pocket_spoc_clicks", "firefox_desk
 
 days_of_use = ConfigLoader.get_metric("days_of_use", "firefox_desktop")
 
-qualified_cumulative_days_of_use = ConfigLoader.get_metric("qualified_cumulative_days_of_use", "firefox_desktop")
+qualified_cumulative_days_of_use = ConfigLoader.get_metric(
+    "qualified_cumulative_days_of_use", "firefox_desktop"
+)
 
-disable_pocket_clicks = ConfigLoader.get_metric("disable_pocket_clicks", "firefox_desktop")
+disable_pocket_clicks = ConfigLoader.get_metric(
+    "disable_pocket_clicks", "firefox_desktop"
+)
 
-disable_pocket_spocs_clicks = ConfigLoader.get_metric("disable_pocket_spocs_clicks", "firefox_desktop")
+disable_pocket_spocs_clicks = ConfigLoader.get_metric(
+    "disable_pocket_spocs_clicks", "firefox_desktop"
+)

--- a/src/mozanalysis/metrics/desktop.py
+++ b/src/mozanalysis/metrics/desktop.py
@@ -1,404 +1,62 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-from textwrap import dedent
 
-from mozanalysis.metrics import DataSource, Metric, agg_any, agg_sum
+from mozanalysis.config import ConfigLoader
 
-#: DataSource: The clients_daily table.
-clients_daily = DataSource(
-    name="clients_daily",
-    from_expr="mozdata.telemetry.clients_daily",
-)
+clients_daily = ConfigLoader.get_data_source("clients_daily", "firefox_desktop")
 
-#: DataSource: The `search_clients_engines_sources_daily`_ table.
-#: This table unpacks search counts from the main ping;
-#: it contains one row per (client_id, submission_date, engine, source).
-#:
-#: .. _`search_clients_engines_sources_daily`: https://docs.telemetry.mozilla.org/
-#:    datasets/search/search_clients_engines_sources_daily/reference.html
-search_clients_engines_sources_daily = DataSource(
-    name="search_clients_engines_sources_daily",
-    from_expr="mozdata.search.search_clients_engines_sources_daily",
-    experiments_column_type=None,
-)
+search_clients_engines_sources_daily = ConfigLoader.get_data_source("search_clients_engines_sources_daily", "firefox_desktop")
 
-#: DataSource: A clone of `search_clients_engines_sources_daily`.
-#: Exists for backwards compatibility; new uses should use the new name.
-search_clients_daily = search_clients_engines_sources_daily
+search_clients_daily = ConfigLoader.get_data_source("search_clients_engines_sources_daily", "firefox_desktop")
 
-#: DataSource: The main_summary table.
-main_summary = DataSource(
-    name="main_summary", from_expr="mozdata.telemetry.main_summary"
-)
+main_summary = ConfigLoader.get_data_source("main_summary", "firefox_desktop")
 
-#: DataSource: The events table.
-events = DataSource(
-    name="events",
-    from_expr="mozdata.telemetry.events",
-    experiments_column_type="native",
-)
+events = ConfigLoader.get_data_source("events", "firefox_desktop")
 
-#: DataSource: Normandy events; a subset of the events table.
-#: The telemetry.events table is clustered by event_category.
-#: Normandy accounts for about 10% of event volume, so this dramatically
-#: reduces bytes queried compared to counting rows from the generic events DataSource.
-normandy_events = DataSource(
-    name="normandy_events",
-    from_expr="""(
-        SELECT
-            *
-        FROM mozdata.telemetry.events
-        WHERE event_category = 'normandy'
-    )""",
-    experiments_column_type="native",
-)
+normandy_events = ConfigLoader.get_data_source("normandy_events", "firefox_desktop")
 
-#: DataSource: The telemetry_stable.main_v4 ping table.
-#: The main_v4 table is what backs the telemetry.main view.
-#: Referencing the table directly helps us stay under the BigQuery
-#: query complexity budget.
-main = DataSource(
-    name="main",
-    from_expr="""(
-                SELECT
-                    *,
-                    DATE(submission_timestamp) AS submission_date,
-                    environment.experiments
-                FROM `moz-fx-data-shared-prod`.telemetry_stable.main_v4
-            )""",
-    experiments_column_type="native",
-)
+main = ConfigLoader.get_data_source("main", "firefox_desktop")
 
-#: DataSource: The telemetry.crash ping table.
-crash = DataSource(
-    name="crash",
-    from_expr="""(
-                SELECT
-                    *,
-                    DATE(submission_timestamp) AS submission_date,
-                    environment.experiments
-                FROM mozdata.telemetry.crash
-            )""",
-    experiments_column_type="native",
-)
+crash = ConfigLoader.get_data_source("crash", "firefox_desktop")
 
-#: DataSource: The ``messaging_system.cfr`` table.
-cfr = DataSource(
-    name="cfr",
-    from_expr="""(
-                SELECT
-                    *,
-                    DATE(submission_timestamp) AS submission_date
-                FROM `moz-fx-data-derived-datasets`.messaging_system.cfr
-            )""",
-    experiments_column_type="native",
-)
+cfr = ConfigLoader.get_data_source("cfr", "firefox_desktop")
 
-#: DataSource: The ``activity_stream.events`` table.
-activity_stream_events = DataSource(
-    name="activity_stream_events",
-    from_expr="""(
-                SELECT
-                    *,
-                    DATE(submission_timestamp) AS submission_date
-                FROM mozdata.activity_stream.events
-            )""",
-    experiments_column_type="native",
-)
+activity_stream_events = ConfigLoader.get_data_source("activity_stream_events", "firefox_desktop")
 
 
-#: Metric: ...
-active_hours = Metric(
-    name="active_hours",
-    data_source=clients_daily,
-    select_expr=agg_sum("active_hours_sum"),
-    friendly_name="Active hours",
-    description=dedent(
-        """\
-        Measures the amount of time (in 5-second increments) during which
-        Firefox received user input from a keyboard or mouse. The Firefox
-        window does not need to be focused.
-    """
-    ),
-)
+active_hours = ConfigLoader.get_metric("active_hours", "firefox_desktop")
 
-#: Metric: ...
-uri_count = Metric(
-    name="uri_count",
-    data_source=clients_daily,
-    select_expr=agg_sum("scalar_parent_browser_engagement_total_uri_count_sum"),
-    friendly_name="URIs visited",
-    description=dedent(
-        """\
-        Counts the total number of URIs visited.
-        Includes within-page navigation events (e.g. to anchors).
-    """
-    ),
-)
+uri_count = ConfigLoader.get_metric("uri_count", "firefox_desktop")
 
-#: Metric: ...
-search_count = Metric(
-    name="search_count",
-    data_source=search_clients_engines_sources_daily,
-    select_expr=agg_sum("sap"),
-    friendly_name="SAP searches",
-    description=dedent(
-        """\
-        Counts the number of searches a user performed through Firefox's
-        Search Access Points.
-        Learn more in the
-        [search data documentation](https://docs.telemetry.mozilla.org/datasets/search.html).
-    """  # noqa:E501
-    ),
-)
+search_count = ConfigLoader.get_metric("search_count", "firefox_desktop")
 
-#: Metric: ...
-tagged_search_count = Metric(
-    name="tagged_search_count",
-    data_source=search_clients_engines_sources_daily,
-    select_expr=agg_sum("tagged_sap"),
-    friendly_name="Tagged SAP searches",
-    description=dedent(
-        """\
-        Counts the number of searches a user performed through Firefox's
-        Search Access Points that were submitted with a partner code
-        and were potentially revenue-generating.
-        Learn more in the
-        [search data documentation](https://docs.telemetry.mozilla.org/datasets/search.html).
-    """  # noqa:E501
-    ),
-)
+tagged_search_count = ConfigLoader.get_metric("tagged_search_count", "firefox_desktop")
 
-#: Metric: ...
-tagged_follow_on_search_count = Metric(
-    name="tagged_follow_on_search_count",
-    data_source=search_clients_engines_sources_daily,
-    select_expr=agg_sum("tagged_follow_on"),
-    friendly_name="Tagged follow-on searches",
-    description=dedent(
-        """\
-        Counts the number of follow-on searches with a Mozilla partner tag.
-        These are additional searches that users performed from a search engine
-        results page after executing a tagged search through a SAP.
-        Learn more in the
-        [search data documentation](https://docs.telemetry.mozilla.org/datasets/search.html).
-    """  # noqa:E501
-    ),
-)
+tagged_follow_on_search_count = ConfigLoader.get_metric("tagged_follow_on_search_count", "firefox_desktop")
 
-#: Metric: ...
-ad_clicks = Metric(
-    name="ad_clicks",
-    data_source=search_clients_engines_sources_daily,
-    select_expr=agg_sum("ad_click"),
-    friendly_name="Ad clicks",
-    description=dedent(
-        """\
-        Counts clicks on ads on search engine result pages with a Mozilla
-        partner tag.
-    """
-    ),
-)
+ad_clicks = ConfigLoader.get_metric("ad_clicks", "firefox_desktop")
 
-#: Metric: ...
-searches_with_ads = Metric(
-    name="searches_with_ads",
-    data_source=search_clients_engines_sources_daily,
-    select_expr=agg_sum("search_with_ads"),
-    friendly_name="Search result pages with ads",
-    description=dedent(
-        """\
-        Counts search result pages served with advertising.
-        Users may not actually see these ads thanks to e.g. ad-blockers.
-        Learn more in the
-        [search analysis documentation](https://mozilla-private.report/search-analysis-docs/book/in_content_searches.html).
-    """  # noqa:E501
-    ),
-)
+searches_with_ads = ConfigLoader.get_metric("searches_with_ads", "firefox_desktop")
 
-#: Metric: ...
-organic_search_count = Metric(
-    name="organic_search_count",
-    data_source=search_clients_engines_sources_daily,
-    select_expr=agg_sum("organic"),
-    friendly_name="Organic searches",
-    description=dedent(
-        """\
-        Counts organic searches, which are searches that are _not_ performed
-        through a Firefox SAP and which are not monetizable.
-        Learn more in the
-        [search data documentation](https://docs.telemetry.mozilla.org/datasets/search.html).
-    """  # noqa:E501
-    ),
-)
+organic_search_count = ConfigLoader.get_metric("organic_search_count", "firefox_desktop")
 
-#: Metric: ...
-unenroll = Metric(
-    name="unenroll",
-    data_source=normandy_events,
-    select_expr=agg_any(
-        """
-                event_category = 'normandy'
-                AND event_method = 'unenroll'
-                AND event_string_value = '{experiment_slug}'
-            """
-    ),
-    friendly_name="Unenrollments",
-    description=dedent(
-        """\
-        Counts the number of clients with an experiment unenrollment event.
-    """
-    ),
-    bigger_is_better=False,
-)
+unenroll = ConfigLoader.get_metric("unenroll", "firefox_desktop")
 
-#: Metric: ...
-view_about_logins = Metric(
-    name="view_about_logins",
-    data_source=events,
-    select_expr=agg_any(
-        """
-                event_method = 'open_management'
-                AND event_category = 'pwmgr'
-            """
-    ),
-    friendly_name="about:logins viewers",
-    description=dedent(
-        """\
-        Counts the number of clients that viewed about:logins.
-    """
-    ),
-)
+view_about_logins = ConfigLoader.get_metric("view_about_logins", "firefox_desktop")
 
-#: Metric: ...
-view_about_protections = Metric(
-    name="view_about_protections",
-    data_source=events,
-    select_expr=agg_any(
-        """
-                event_method = 'show'
-                AND event_object = 'protection_report'
-            """
-    ),
-    friendly_name="about:protections viewers",
-    description=dedent(
-        """\
-        Counts the number of clients that viewed about:protections.
-    """
-    ),
-)
+view_about_protections = ConfigLoader.get_metric("view_about_protections", "firefox_desktop")
 
-#: Metric: ...
-connect_fxa = Metric(
-    name="connect_fxa",
-    data_source=events,
-    select_expr=agg_any(
-        """
-                event_method = 'connect'
-                AND event_object = 'account'
-            """
-    ),
-    friendly_name="Connected FxA",
-    description=dedent(
-        """\
-        Counts the number of clients that took action to connect to FxA.
-        This does not include clients that were already connected to FxA at
-        the start of the experiment and remained connected.
-    """
-    ),
-)
+connect_fxa = ConfigLoader.get_metric("connect_fxa", "firefox_desktop")
 
-#: Metric: Pocket organic rec clicks in New Tab
-pocket_rec_clicks = Metric(
-    name="pocket_rec_clicks",
-    data_source=activity_stream_events,
-    select_expr="""COUNTIF(
-                event = 'CLICK'
-                AND source = 'CARDGRID'
-                AND JSON_EXTRACT_SCALAR(value, '$.card_type') = 'organic'
-            )""",
-    friendly_name="Clicked Pocket organic recs in New Tab",
-    description=dedent(
-        """\
-         Counts the number of Pocket rec clicks made by each client.
-    """
-    ),
-)
+pocket_rec_clicks = ConfigLoader.get_metric("pocket_rec_clicks", "firefox_desktop")
 
-#: Metric: Pocket sponsored content clicks in New Tab
-pocket_spoc_clicks = Metric(
-    name="pocket_spoc_clicks",
-    data_source=activity_stream_events,
-    select_expr="""COUNTIF(
-                event = 'CLICK'
-                AND source = 'CARDGRID'
-                AND JSON_EXTRACT_SCALAR(value, '$.card_type') = 'spoc'
-            )""",
-    friendly_name="Clicked Pocket sponsored content in New Tab",
-    description=dedent(
-        """\
-         Counts the number of Pocket sponsored content clicks made by each client.
-    """
-    ),
-)
+pocket_spoc_clicks = ConfigLoader.get_metric("pocket_spoc_clicks", "firefox_desktop")
 
-#: Metric: ...
-days_of_use = Metric(
-    name="days_of_use",
-    data_source=clients_daily,
-    select_expr="COUNT(ds.submission_date)",
-    friendly_name="Days of use",
-    description="The number of days in the interval that each client sent a main ping.",
-)
+days_of_use = ConfigLoader.get_metric("days_of_use", "firefox_desktop")
 
-qualified_cumulative_days_of_use = Metric(
-    name="qualified_cumulative_days_of_use",
-    data_source=clients_daily,
-    select_expr="""COUNTIF(
-        active_hours_sum > 0 AND
-        scalar_parent_browser_engagement_total_uri_count_normal_and_private_mode_sum > 0
-      )""",
-    friendly_name="QCDOU",
-    description=dedent(
-        """\
-         The number of days in the interval that each client sent a main ping,
-         given that the client had >0 active hours and >0 URIs loaded.
-        """
-    ),
-)
+qualified_cumulative_days_of_use = ConfigLoader.get_metric("qualified_cumulative_days_of_use", "firefox_desktop")
 
-#: Metric: Clicks to disable Pocket in New Tab
-disable_pocket_clicks = Metric(
-    name="disable_pocket_clicks",
-    data_source=activity_stream_events,
-    select_expr="""COUNTIF(
-                event = 'PREF_CHANGED'
-                AND source = 'TOP_STORIES'
-                AND JSON_EXTRACT_SCALAR(value, '$.status') = 'false'
-            )""",
-    friendly_name="Disabled Pocket in New Tab",
-    description=dedent(
-        """\
-         Counts the number of clicks to disable Pocket in New Tab made by each client.
-    """
-    ),
-)
+disable_pocket_clicks = ConfigLoader.get_metric("disable_pocket_clicks", "firefox_desktop")
 
-#: Metric: Clicks to disable Pocket sponsored content in New Tab
-disable_pocket_spocs_clicks = Metric(
-    name="disable_pocket_spocs_clicks",
-    data_source=activity_stream_events,
-    select_expr="""COUNTIF(
-                event = 'PREF_CHANGED'
-                AND source = 'POCKET_SPOCS'
-                AND JSON_EXTRACT_SCALAR(value, '$.status') = 'false'
-            )""",
-    friendly_name="Disabled Pocket sponsored content in New Tab",
-    description=dedent(
-        """\
-         Counts the number of clicks to disable Pocket sponsored content
-         in New Tab made by each client.
-    """
-    ),
-)
+disable_pocket_spocs_clicks = ConfigLoader.get_metric("disable_pocket_spocs_clicks", "firefox_desktop")

--- a/src/mozanalysis/metrics/fenix.py
+++ b/src/mozanalysis/metrics/fenix.py
@@ -2,6 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# These metric definitions are deprected.
+# Instead use the metric slug to reference metrics defined
+# in https://github.com/mozilla/jetstream-config
+
 from mozanalysis.config import ConfigLoader
 
 baseline = ConfigLoader.get_data_source("baseline", "fenix")

--- a/src/mozanalysis/metrics/fenix.py
+++ b/src/mozanalysis/metrics/fenix.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# These metric definitions are deprected.
+# These metric definitions are deprecated.
 # Instead use the metric slug to reference metrics defined
 # in https://github.com/mozilla/jetstream-config
 

--- a/src/mozanalysis/metrics/fenix.py
+++ b/src/mozanalysis/metrics/fenix.py
@@ -2,112 +2,24 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from mozanalysis.metrics import DataSource, Metric, agg_sum
-
-#: DataSource: The baseline ping table.
-baseline = DataSource(
-    name="baseline",
-    from_expr="""(
-                SELECT
-                    p.*,
-                    DATE(p.submission_timestamp) AS submission_date
-                FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
-            )""",
-    client_id_column="client_info.client_id",
-    experiments_column_type="glean",
-    default_dataset="org_mozilla_firefox",
-)
+from mozanalysis.config import ConfigLoader
 
 
-#: DataSource: Events table.
-#: For convenience, this is exploded to one-row-per-event
-#: like the ``telemetry.events`` dataset.
-events = DataSource(
-    name="events",
-    from_expr="""(
-                SELECT
-                    p.* EXCEPT (events),
-                    DATE(p.submission_timestamp) AS submission_date,
-                    event
-                FROM
-                    `moz-fx-data-shared-prod.{dataset}.events` p
-                CROSS JOIN
-                    UNNEST(p.events) AS event
-            )""",
-    client_id_column="client_info.client_id",
-    experiments_column_type="glean",
-    default_dataset="org_mozilla_firefox",
-)
+baseline = ConfigLoader.get_data_source("baseline", "fenix")
+
+events = ConfigLoader.get_data_source("events", "fenix")
+
+metrics = ConfigLoader.get_data_source("metrics", "fenix")
 
 
-#: DataSource: Metrics ping table.
-metrics = DataSource(
-    name="metrics",
-    from_expr="""(
-                SELECT
-                    p.*,
-                    DATE(p.submission_timestamp) AS submission_date
-                FROM `moz-fx-data-shared-prod.{dataset}.metrics` p
-            )""",
-    client_id_column="client_info.client_id",
-    experiments_column_type="glean",
-    default_dataset="org_mozilla_firefox",
-)
+uri_count = ConfigLoader.get_metric("uri_count", "fenix")
 
+user_reports_site_issue_count = ConfigLoader.get_metric("user_reports_site_issue_count", "fenix")
 
-#: Metric: ...
-uri_count = Metric(
-    name="uri_count",
-    data_source=baseline,
-    select_expr=agg_sum("metrics.counter.events_total_uri_count"),
-    friendly_name="URIs visited",
-    description="Counts the number of URIs each client visited",
-)
+user_reload_count = ConfigLoader.get_metric("user_reload_count", "fenix")
 
-#: Metric: ...
-user_reports_site_issue_count = Metric(
-    name="user_reports_site_issue_count",
-    data_source=events,
-    select_expr="COUNTIF(event.name = 'browser_menu_action' AND "
-    + "mozfun.map.get_key('event.extra', 'item') = 'report_site_issue')",
-    friendly_name="Site issues reported",
-    description="Counts the number of times clients reported an issue with a site.",
-)
+baseline_ping_count = ConfigLoader.get_metric("baseline_ping_count", "fenix")
 
-#: Metric: ...
-user_reload_count = Metric(
-    name="user_reload_count",
-    data_source=events,
-    select_expr="COUNTIF(event.name = 'browser_menu_action' AND "
-    + "mozfun.map.get_key('event.extra', 'item') = 'reload')",
-    friendly_name="Pages reloaded",
-    description="Counts the number of times a client reloaded a page.",
-    bigger_is_better=False,
-)
+metric_ping_count = ConfigLoader.get_metric("metric_ping_count", "fenix")
 
-#: Metric: ...
-baseline_ping_count = Metric(
-    name="baseline_ping_count",
-    data_source=baseline,
-    select_expr="COUNT(document_id)",
-    friendly_name="Baseline pings",
-    description="Counts the number of `baseline` pings received from each client.",
-)
-
-#: Metric: ...
-metric_ping_count = Metric(
-    name="metric_ping_count",
-    data_source=metrics,
-    select_expr="COUNT(document_id)",
-    friendly_name="Metrics pings",
-    description="Counts the number of `metrics` pings received from each client.",
-)
-
-#: Metric: ...
-first_run_date = Metric(
-    name="first_run_date",
-    data_source=baseline,
-    select_expr="MIN(client_info.first_run_date)",
-    friendly_name="First run date",
-    description="The earliest first-run date reported by each client.",
-)
+first_run_date = ConfigLoader.get_metric("first_run_date", "fenix")

--- a/src/mozanalysis/metrics/fenix.py
+++ b/src/mozanalysis/metrics/fenix.py
@@ -4,7 +4,6 @@
 
 from mozanalysis.config import ConfigLoader
 
-
 baseline = ConfigLoader.get_data_source("baseline", "fenix")
 
 events = ConfigLoader.get_data_source("events", "fenix")

--- a/src/mozanalysis/metrics/fenix.py
+++ b/src/mozanalysis/metrics/fenix.py
@@ -13,7 +13,9 @@ metrics = ConfigLoader.get_data_source("metrics", "fenix")
 
 uri_count = ConfigLoader.get_metric("uri_count", "fenix")
 
-user_reports_site_issue_count = ConfigLoader.get_metric("user_reports_site_issue_count", "fenix")
+user_reports_site_issue_count = ConfigLoader.get_metric(
+    "user_reports_site_issue_count", "fenix"
+)
 
 user_reload_count = ConfigLoader.get_metric("user_reload_count", "fenix")
 

--- a/src/mozanalysis/metrics/firefox_ios.py
+++ b/src/mozanalysis/metrics/firefox_ios.py
@@ -2,6 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# These metric definitions are deprected.
+# Instead use the metric slug to reference metrics defined
+# in https://github.com/mozilla/jetstream-config
+
 from mozanalysis.config import ConfigLoader
 
 baseline = ConfigLoader.get_data_source("baseline", "firefox_ios")

--- a/src/mozanalysis/metrics/firefox_ios.py
+++ b/src/mozanalysis/metrics/firefox_ios.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# These metric definitions are deprected.
+# These metric definitions are deprecated.
 # Instead use the metric slug to reference metrics defined
 # in https://github.com/mozilla/jetstream-config
 

--- a/src/mozanalysis/metrics/firefox_ios.py
+++ b/src/mozanalysis/metrics/firefox_ios.py
@@ -2,81 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from mozanalysis.metrics import DataSource, Metric
+from mozanalysis.config import ConfigLoader
 
-#: DataSource: The baseline ping table.
-baseline = DataSource(
-    name="baseline",
-    from_expr="""(
-                SELECT
-                    p.*,
-                    DATE(p.submission_timestamp) AS submission_date
-                FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
-            )""",
-    client_id_column="client_info.client_id",
-    experiments_column_type="glean",
-    default_dataset="org_mozilla_ios_firefox",
-)
+baseline = ConfigLoader.get_data_source("baseline", "firefox_ios")
 
+events = ConfigLoader.get_data_source("events", "firefox_ios")
 
-#: DataSource: Events table.
-#: For convenience, this is exploded to one-row-per-event
-#: like the ``telemetry.events`` dataset.
-events = DataSource(
-    name="events",
-    from_expr="""(
-                SELECT
-                    p.* EXCEPT (events),
-                    DATE(p.submission_timestamp) AS submission_date,
-                    event
-                FROM
-                    `moz-fx-data-shared-prod.{dataset}.events` p
-                CROSS JOIN
-                    UNNEST(p.events) AS event
-            )""",
-    client_id_column="client_info.client_id",
-    experiments_column_type="glean",
-    default_dataset="org_mozilla_ios_firefox",
-)
+metrics = ConfigLoader.get_data_source("metrics", "firefox_ios")
 
+baseline_ping_count = ConfigLoader.get_metric("baseline_ping_count", "firefox_ios")
 
-#: DataSource: Metrics ping table.
-metrics = DataSource(
-    name="metrics",
-    from_expr="""(
-                SELECT
-                    p.*,
-                    DATE(p.submission_timestamp) AS submission_date
-                FROM `moz-fx-data-shared-prod.{dataset}.metrics` p
-            )""",
-    client_id_column="client_info.client_id",
-    experiments_column_type="glean",
-    default_dataset="org_mozilla_ios_firefox",
-)
+metric_ping_count = ConfigLoader.get_metric("metric_ping_count", "firefox_ios")
 
-#: Metric: ...
-baseline_ping_count = Metric(
-    name="baseline_ping_count",
-    data_source=baseline,
-    select_expr="COUNT(document_id)",
-    friendly_name="Baseline pings",
-    description="Counts the number of `baseline` pings received from each client.",
-)
-
-#: Metric: ...
-metric_ping_count = Metric(
-    name="metric_ping_count",
-    data_source=metrics,
-    select_expr="COUNT(document_id)",
-    friendly_name="Metrics pings",
-    description="Counts the number of `metrics` pings received from each client.",
-)
-
-#: Metric: ...
-first_run_date = Metric(
-    name="first_run_date",
-    data_source=baseline,
-    select_expr="MIN(client_info.first_run_date)",
-    friendly_name="First run date",
-    description="The earliest first-run date reported by each client.",
-)
+first_run_date = ConfigLoader.get_metric("first_run_date", "firefox_ios")

--- a/src/mozanalysis/metrics/focus_android.py
+++ b/src/mozanalysis/metrics/focus_android.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# These metric definitions are deprected.
+# These metric definitions are deprecated.
 # Instead use the metric slug to reference metrics defined
 # in https://github.com/mozilla/jetstream-config
 

--- a/src/mozanalysis/metrics/focus_android.py
+++ b/src/mozanalysis/metrics/focus_android.py
@@ -2,6 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# These metric definitions are deprected.
+# Instead use the metric slug to reference metrics defined
+# in https://github.com/mozilla/jetstream-config
+
 from mozanalysis.config import ConfigLoader
 
 baseline = ConfigLoader.get_data_source("baseline", "focus_android")

--- a/src/mozanalysis/metrics/focus_android.py
+++ b/src/mozanalysis/metrics/focus_android.py
@@ -2,72 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from mozanalysis.metrics import DataSource, Metric
+from mozanalysis.config import ConfigLoader
 
-baseline = DataSource(
-    name="baseline",
-    from_expr="""(
-                SELECT
-                    p.*,
-                    DATE(p.submission_timestamp) AS submission_date
-                FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
-            )""",
-    client_id_column="client_info.client_id",
-    experiments_column_type="glean",
-    default_dataset="org_mozilla_focus",
-)
+baseline = ConfigLoader.get_data_source("baseline", "focus_android")
 
+events = ConfigLoader.get_data_source("events", "focus_android")
 
-events = DataSource(
-    name="events",
-    from_expr="""(
-                SELECT
-                    p.* EXCEPT (events),
-                    DATE(p.submission_timestamp) AS submission_date,
-                    event
-                FROM
-                    `moz-fx-data-shared-prod.{dataset}.events` p
-                CROSS JOIN
-                    UNNEST(p.events) AS event
-            )""",
-    client_id_column="client_info.client_id",
-    experiments_column_type="glean",
-    default_dataset="org_mozilla_focus",
-)
+metrics = ConfigLoader.get_data_source("metrics", "focus_android")
 
-metrics = DataSource(
-    name="metrics",
-    from_expr="""(
-                SELECT
-                    p.*,
-                    DATE(p.submission_timestamp) AS submission_date
-                FROM `moz-fx-data-shared-prod.{dataset}.metrics` p
-            )""",
-    client_id_column="client_info.client_id",
-    experiments_column_type="glean",
-    default_dataset="org_mozilla_focus",
-)
+baseline_ping_count = ConfigLoader.get_metric("baseline_ping_count", "focus_android")
 
-baseline_ping_count = Metric(
-    name="baseline_ping_count",
-    data_source=baseline,
-    select_expr="COUNT(document_id)",
-    friendly_name="Baseline pings",
-    description="Counts the number of `baseline` pings received from each client.",
-)
+metric_ping_count = ConfigLoader.get_metric("metric_ping_count", "focus_android")
 
-metric_ping_count = Metric(
-    name="metric_ping_count",
-    data_source=metrics,
-    select_expr="COUNT(document_id)",
-    friendly_name="Metrics pings",
-    description="Counts the number of `metrics` pings received from each client.",
-)
-
-first_run_date = Metric(
-    name="first_run_date",
-    data_source=baseline,
-    select_expr="MIN(client_info.first_run_date)",
-    friendly_name="First run date",
-    description="The earliest first-run date reported by each client.",
-)
+first_run_date = ConfigLoader.get_metric("first_run_date", "focus_android")

--- a/src/mozanalysis/metrics/focus_ios.py
+++ b/src/mozanalysis/metrics/focus_ios.py
@@ -2,6 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# These metric definitions are deprected.
+# Instead use the metric slug to reference metrics defined
+# in https://github.com/mozilla/jetstream-config
+
 from mozanalysis.config import ConfigLoader
 
 baseline = ConfigLoader.get_data_source("baseline", "focus_ios")

--- a/src/mozanalysis/metrics/focus_ios.py
+++ b/src/mozanalysis/metrics/focus_ios.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# These metric definitions are deprected.
+# These metric definitions are deprecated.
 # Instead use the metric slug to reference metrics defined
 # in https://github.com/mozilla/jetstream-config
 

--- a/src/mozanalysis/metrics/focus_ios.py
+++ b/src/mozanalysis/metrics/focus_ios.py
@@ -2,72 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from mozanalysis.metrics import DataSource, Metric
+from mozanalysis.config import ConfigLoader
 
-baseline = DataSource(
-    name="baseline",
-    from_expr="""(
-                SELECT
-                    p.*,
-                    DATE(p.submission_timestamp) AS submission_date
-                FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
-            )""",
-    client_id_column="client_info.client_id",
-    experiments_column_type="glean",
-    default_dataset="org_mozilla_ios_focus",
-)
+baseline = ConfigLoader.get_data_source("baseline", "focus_ios")
 
+events = ConfigLoader.get_data_source("events", "focus_ios")
 
-events = DataSource(
-    name="events",
-    from_expr="""(
-                SELECT
-                    p.* EXCEPT (events),
-                    DATE(p.submission_timestamp) AS submission_date,
-                    event
-                FROM
-                    `moz-fx-data-shared-prod.{dataset}.events` p
-                CROSS JOIN
-                    UNNEST(p.events) AS event
-            )""",
-    client_id_column="client_info.client_id",
-    experiments_column_type="glean",
-    default_dataset="org_mozilla_ios_focus",
-)
+metrics = ConfigLoader.get_data_source("metrics", "focus_ios")
 
-metrics = DataSource(
-    name="metrics",
-    from_expr="""(
-                SELECT
-                    p.*,
-                    DATE(p.submission_timestamp) AS submission_date
-                FROM `moz-fx-data-shared-prod.{dataset}.metrics` p
-            )""",
-    client_id_column="client_info.client_id",
-    experiments_column_type="glean",
-    default_dataset="org_mozilla_ios_focus",
-)
+baseline_ping_count = ConfigLoader.get_metric("baseline_ping_count", "focus_ios")
 
-baseline_ping_count = Metric(
-    name="baseline_ping_count",
-    data_source=baseline,
-    select_expr="COUNT(document_id)",
-    friendly_name="Baseline pings",
-    description="Counts the number of `baseline` pings received from each client.",
-)
+metric_ping_count = ConfigLoader.get_metric("metric_ping_count", "focus_ios")
 
-metric_ping_count = Metric(
-    name="metric_ping_count",
-    data_source=metrics,
-    select_expr="COUNT(document_id)",
-    friendly_name="Metrics pings",
-    description="Counts the number of `metrics` pings received from each client.",
-)
-
-first_run_date = Metric(
-    name="first_run_date",
-    data_source=baseline,
-    select_expr="MIN(client_info.first_run_date)",
-    friendly_name="First run date",
-    description="The earliest first-run date reported by each client.",
-)
+first_run_date = ConfigLoader.get_metric("first_run_date", "focus_ios")

--- a/src/mozanalysis/metrics/klar_android.py
+++ b/src/mozanalysis/metrics/klar_android.py
@@ -2,72 +2,17 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from mozanalysis.metrics import DataSource, Metric
+from mozanalysis.config import ConfigLoader
 
-baseline = DataSource(
-    name="baseline",
-    from_expr="""(
-                SELECT
-                    p.*,
-                    DATE(p.submission_timestamp) AS submission_date
-                FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
-            )""",
-    client_id_column="client_info.client_id",
-    experiments_column_type="glean",
-    default_dataset="org_mozilla_klar",
-)
+baseline = ConfigLoader.get_data_source("baseline", "klar_android")
+
+events = ConfigLoader.get_data_source("events", "klar_android")
+
+metrics = ConfigLoader.get_data_source("metrics", "klar_android")
 
 
-events = DataSource(
-    name="events",
-    from_expr="""(
-                SELECT
-                    p.* EXCEPT (events),
-                    DATE(p.submission_timestamp) AS submission_date,
-                    event
-                FROM
-                    `moz-fx-data-shared-prod.{dataset}.events` p
-                CROSS JOIN
-                    UNNEST(p.events) AS event
-            )""",
-    client_id_column="client_info.client_id",
-    experiments_column_type="glean",
-    default_dataset="org_mozilla_klar",
-)
+baseline_ping_count = ConfigLoader.get_metric("baseline_ping_count", "klar_android")
 
-metrics = DataSource(
-    name="metrics",
-    from_expr="""(
-                SELECT
-                    p.*,
-                    DATE(p.submission_timestamp) AS submission_date
-                FROM `moz-fx-data-shared-prod.{dataset}.metrics` p
-            )""",
-    client_id_column="client_info.client_id",
-    experiments_column_type="glean",
-    default_dataset="org_mozilla_klar",
-)
+metric_ping_count = ConfigLoader.get_metric("metric_ping_count", "klar_android")
 
-baseline_ping_count = Metric(
-    name="baseline_ping_count",
-    data_source=baseline,
-    select_expr="COUNT(document_id)",
-    friendly_name="Baseline pings",
-    description="Counts the number of `baseline` pings received from each client.",
-)
-
-metric_ping_count = Metric(
-    name="metric_ping_count",
-    data_source=metrics,
-    select_expr="COUNT(document_id)",
-    friendly_name="Metrics pings",
-    description="Counts the number of `metrics` pings received from each client.",
-)
-
-first_run_date = Metric(
-    name="first_run_date",
-    data_source=baseline,
-    select_expr="MIN(client_info.first_run_date)",
-    friendly_name="First run date",
-    description="The earliest first-run date reported by each client.",
-)
+first_run_date = ConfigLoader.get_metric("first_run_date", "klar_android")

--- a/src/mozanalysis/metrics/klar_android.py
+++ b/src/mozanalysis/metrics/klar_android.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# These metric definitions are deprected.
+# These metric definitions are deprecated.
 # Instead use the metric slug to reference metrics defined
 # in https://github.com/mozilla/jetstream-config
 

--- a/src/mozanalysis/metrics/klar_android.py
+++ b/src/mozanalysis/metrics/klar_android.py
@@ -2,6 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# These metric definitions are deprected.
+# Instead use the metric slug to reference metrics defined
+# in https://github.com/mozilla/jetstream-config
+
 from mozanalysis.config import ConfigLoader
 
 baseline = ConfigLoader.get_data_source("baseline", "klar_android")

--- a/src/mozanalysis/metrics/klar_ios.py
+++ b/src/mozanalysis/metrics/klar_ios.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# These metric definitions are deprected.
+# These metric definitions are deprecated.
 # Instead use the metric slug to reference metrics defined
 # in https://github.com/mozilla/jetstream-config
 

--- a/src/mozanalysis/metrics/klar_ios.py
+++ b/src/mozanalysis/metrics/klar_ios.py
@@ -2,6 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# These metric definitions are deprected.
+# Instead use the metric slug to reference metrics defined
+# in https://github.com/mozilla/jetstream-config
+
 from mozanalysis.config import ConfigLoader
 
 baseline = ConfigLoader.get_data_source("baseline", "klar_ios")

--- a/src/mozanalysis/metrics/klar_ios.py
+++ b/src/mozanalysis/metrics/klar_ios.py
@@ -2,72 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from mozanalysis.metrics import DataSource, Metric
+from mozanalysis.config import ConfigLoader
 
-baseline = DataSource(
-    name="baseline",
-    from_expr="""(
-                SELECT
-                    p.*,
-                    DATE(p.submission_timestamp) AS submission_date
-                FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
-            )""",
-    client_id_column="client_info.client_id",
-    experiments_column_type="glean",
-    default_dataset="org_mozilla_ios_klar",
-)
+baseline = ConfigLoader.get_data_source("baseline", "klar_ios")
 
+events = ConfigLoader.get_data_source("events", "klar_ios")
 
-events = DataSource(
-    name="events",
-    from_expr="""(
-                SELECT
-                    p.* EXCEPT (events),
-                    DATE(p.submission_timestamp) AS submission_date,
-                    event
-                FROM
-                    `moz-fx-data-shared-prod.{dataset}.events` p
-                CROSS JOIN
-                    UNNEST(p.events) AS event
-            )""",
-    client_id_column="client_info.client_id",
-    experiments_column_type="glean",
-    default_dataset="org_mozilla_ios_klar",
-)
+metrics = ConfigLoader.get_data_source("metrics", "klar_ios")
 
-metrics = DataSource(
-    name="metrics",
-    from_expr="""(
-                SELECT
-                    p.*,
-                    DATE(p.submission_timestamp) AS submission_date
-                FROM `moz-fx-data-shared-prod.{dataset}.metrics` p
-            )""",
-    client_id_column="client_info.client_id",
-    experiments_column_type="glean",
-    default_dataset="org_mozilla_ios_klar",
-)
+baseline_ping_count = ConfigLoader.get_metric("baseline_ping_count", "klar_ios")
 
-baseline_ping_count = Metric(
-    name="baseline_ping_count",
-    data_source=baseline,
-    select_expr="COUNT(document_id)",
-    friendly_name="Baseline pings",
-    description="Counts the number of `baseline` pings received from each client.",
-)
+metric_ping_count = ConfigLoader.get_metric("metric_ping_count", "klar_ios")
 
-metric_ping_count = Metric(
-    name="metric_ping_count",
-    data_source=metrics,
-    select_expr="COUNT(document_id)",
-    friendly_name="Metrics pings",
-    description="Counts the number of `metrics` pings received from each client.",
-)
-
-first_run_date = Metric(
-    name="first_run_date",
-    data_source=baseline,
-    select_expr="MIN(client_info.first_run_date)",
-    friendly_name="First run date",
-    description="The earliest first-run date reported by each client.",
-)
+first_run_date = ConfigLoader.get_metric("first_run_date", "klar_ios")

--- a/src/mozanalysis/segments/desktop.py
+++ b/src/mozanalysis/segments/desktop.py
@@ -1,82 +1,18 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-from textwrap import dedent
 
-from mozanalysis.metrics import agg_any
-from mozanalysis.segments import Segment, SegmentDataSource
+from mozanalysis.config import ConfigLoader
 
-#: SegmentDataSource: The clients_last_seen table.
-clients_last_seen = SegmentDataSource(
-    name="clients_last_seen",
-    from_expr="mozdata.telemetry.clients_last_seen",
-    window_start=0,
-    window_end=0,
-)
+clients_last_seen = ConfigLoader.get_segment_data_source("clients_last_seen", "firefox_desktop")
 
-#: Segment: ...
-regular_users_v3 = Segment(
-    name="regular_users_v3",
-    data_source=clients_last_seen,
-    select_expr=agg_any("is_regular_user_v3"),
-    friendly_name="Regular users (v3)",
-    description=dedent(
-        """\
-        Clients who used Firefox on at least 14 of the 27 days prior to enrolling.
-        This segment is characterized by high retention.
-        """
-    ),
-)
+regular_users_v3 = ConfigLoader.get_segment_data_source("regular_users_v3", "firefox_desktop")
 
-#: Segment: ...
-new_or_resurrected_v3 = Segment(
-    name="new_or_resurrected_v3",
-    data_source=clients_last_seen,
-    select_expr="LOGICAL_OR(COALESCE(is_new_or_resurrected_v3, TRUE))",
-    friendly_name="New or resurrected users (v3)",
-    description=dedent(
-        """\
-        Clients who used Firefox on none of the 27 days prior to enrolling.
-        """
-    ),
-)
+new_or_resurrected_v3 = ConfigLoader.get_segment_data_source("new_or_resurrected_v3", "firefox_desktop")
 
-#: Segment: ...
-weekday_regular_v1 = Segment(
-    name="weekday_regular_v1",
-    data_source=clients_last_seen,
-    select_expr=agg_any("is_weekday_regular_v1"),
-    friendly_name="Weekday regular users (v1)",
-    description=dedent(
-        """\
-        A subset of "regular users" who typically use Firefox on weekdays.
-        """
-    ),
-)
 
-#: Segment: ...
-allweek_regular_v1 = Segment(
-    name="allweek_regular_v1",
-    data_source=clients_last_seen,
-    select_expr=agg_any("is_allweek_regular_v1"),
-    friendly_name="All-week regulars (v1)",
-    description=dedent(
-        """\
-        A subset of "regular users" that have used Firefox on weekends.
-        """
-    ),
-)
+weekday_regular_v1 = ConfigLoader.get_segment("weekday_regular_v1", "firefox_desktop")
 
-#: Segment: ...
-new_unique_profiles = Segment(
-    name="new_unique_profiles",
-    data_source=clients_last_seen,
-    select_expr="COALESCE(ANY_VALUE(first_seen_date) >= submission_date, TRUE)",
-    friendly_name="New unique profiles",
-    description=dedent(
-        """\
-        Clients that enrolled the first date their client_id ever appeared
-        in telemetry (i.e. new, unique profiles).
-    """
-    ),
-)
+allweek_regular_v1 = ConfigLoader.get_segment("allweek_regular_v1", "firefox_desktop")
+
+new_unique_profiles = ConfigLoader.get_segment("new_unique_profiles", "firefox_desktop")

--- a/src/mozanalysis/segments/desktop.py
+++ b/src/mozanalysis/segments/desktop.py
@@ -4,12 +4,16 @@
 
 from mozanalysis.config import ConfigLoader
 
-clients_last_seen = ConfigLoader.get_segment_data_source("clients_last_seen", "firefox_desktop")
+clients_last_seen = ConfigLoader.get_segment_data_source(
+    "clients_last_seen", "firefox_desktop"
+)
 
-regular_users_v3 = ConfigLoader.get_segment_data_source("regular_users_v3", "firefox_desktop")
 
-new_or_resurrected_v3 = ConfigLoader.get_segment_data_source("new_or_resurrected_v3", "firefox_desktop")
+regular_users_v3 = ConfigLoader.get_segment("regular_users_v3", "firefox_desktop")
 
+new_or_resurrected_v3 = ConfigLoader.get_segment(
+    "new_or_resurrected_v3", "firefox_desktop"
+)
 
 weekday_regular_v1 = ConfigLoader.get_segment("weekday_regular_v1", "firefox_desktop")
 

--- a/src/mozanalysis/segments/desktop.py
+++ b/src/mozanalysis/segments/desktop.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# These segment definitions are deprected.
+# These segment definitions are deprecated.
 # Instead use the segment slug to reference segments defined
 # in https://github.com/mozilla/jetstream-config
 

--- a/src/mozanalysis/segments/desktop.py
+++ b/src/mozanalysis/segments/desktop.py
@@ -2,6 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# These segment definitions are deprected.
+# Instead use the segment slug to reference segments defined
+# in https://github.com/mozilla/jetstream-config
+
 from mozanalysis.config import ConfigLoader
 
 clients_last_seen = ConfigLoader.get_segment_data_source(

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -4,6 +4,8 @@ from cheap_lint import sql_lint
 import mozanalysis.metrics.desktop as mad
 import mozanalysis.metrics.fenix
 import mozanalysis.metrics.firefox_ios
+import mozanalysis.metrics.klar_ios
+import mozanalysis.metrics.klar_android
 import mozanalysis.segments.desktop as msd
 from mozanalysis.experiment import AnalysisBasis, AnalysisWindow, Experiment, TimeLimits
 from mozanalysis.exposure import ExposureSignal

--- a/tests/test_segment_libraries.py
+++ b/tests/test_segment_libraries.py
@@ -36,21 +36,21 @@ def test_consistency_of_segment_and_variable_names(included_segments):
 
 
 def test_segment_data_source_window_end_validates():
-    msd.SegmentDataSource(
+    SegmentDataSource(
         name="bla",
         from_expr="bla",
         window_start=0,
         window_end=0,
     )
 
-    msd.SegmentDataSource(
+    SegmentDataSource(
         name="bla",
         from_expr="bla",
         window_start=0,
         window_end=1,
     )
 
-    msd.SegmentDataSource(
+    SegmentDataSource(
         name="bla",
         from_expr="bla",
         window_start=1,
@@ -59,7 +59,7 @@ def test_segment_data_source_window_end_validates():
 
 
 def test_segment_data_source_window_start_validates():
-    msd.SegmentDataSource(
+    SegmentDataSource(
         name="bla",
         from_expr="bla",
         window_start=-1,
@@ -67,7 +67,7 @@ def test_segment_data_source_window_start_validates():
     )
 
     with pytest.raises(ValueError):
-        msd.SegmentDataSource(
+        SegmentDataSource(
             name="bla",
             from_expr="bla",
             window_start=0,
@@ -77,7 +77,7 @@ def test_segment_data_source_window_start_validates():
 
 def test_segment_validates_not_metric_data_source():
     with pytest.raises(TypeError):
-        msd.Segment(
+        Segment(
             name="bla",
             data_source=mmd.clients_daily,
             select_expr="bla",
@@ -91,11 +91,11 @@ def test_included_segments_have_docs(included_segments):
 
 def test_complains_about_template_without_default():
     with pytest.raises(ValueError):
-        msd.SegmentDataSource(
+        SegmentDataSource(
             name="foo",
             from_expr="moz-fx-data-shared-prod.{dataset}.foo",
         )
-    msd.SegmentDataSource(
+    SegmentDataSource(
         name="foo",
         from_expr="moz-fx-data-shared-prod.{dataset}.foo",
         default_dataset="dataset",

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ addopts =
     --black
     --showlocals
     --tb=native
-    --timeout=120
     --capture=no
     --cov=src/
     --cov-report=term-missing

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ addopts =
     --black
     --showlocals
     --tb=native
+    --timeout=120
     --capture=no
     --cov=src/
     --cov-report=term-missing


### PR DESCRIPTION
With this change mozanalysis will use the new [jetstream-config-parser](https://github.com/mozilla/jetstream-config-parser) to pull in configurations from jetstream-config. The changes introduced here shouldn't break any existing code.

I've already migrated existing metric, data source and segment definitions to https://github.com/mozilla/jetstream-config/tree/main/definitions, but it would probably be best to validate them.