### PR TITLE
fix typo in exposures query

### DIFF
--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -738,7 +738,7 @@ class Experiment:
                 `moz-fx-data-shared-prod.telemetry.events`
             WHERE
                 event_category = 'normandy'
-                AND (event_method = 'exposure' AND event_method = 'expose')
+                AND (event_method = 'exposure' OR event_method = 'expose')
                 AND submission_date
                     BETWEEN '{first_enrollment_date}' AND '{last_enrollment_date}'
                 AND event_string_value = '{experiment_slug}'


### PR DESCRIPTION
I am guessing that at some point we switched from `exposure` to `expose` as the `event_method` (or maybe were just leaving open both possibilities) and that this was meant to be `OR` to account for either option.