### PR TITLE
Mbowerman sizing results rename

### DIFF
--- a/src/mozanalysis/frequentist_stats/sample_size.py
+++ b/src/mozanalysis/frequentist_stats/sample_size.py
@@ -2,16 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import attr
-from typing import List, Union, Dict, Callable, Optional
-from datetime import datetime, timedelta
+from typing import List, Union, Dict, Optional
+from datetime import datetime
 
 from mozanalysis.bq import BigQueryContext
 from mozanalysis.experiment import TimeSeriesResult
 from mozanalysis.metrics import Metric
 from mozanalysis.segments import Segment
 from mozanalysis.sizing import HistoricalTarget
-from mozanalysis.utils import add_days, get_time_intervals
+from mozanalysis.utils import get_time_intervals
 
 from scipy.stats import norm
 from math import pi

--- a/src/mozanalysis/frequentist_stats/sample_size.py
+++ b/src/mozanalysis/frequentist_stats/sample_size.py
@@ -142,7 +142,7 @@ def difference_of_proportions_sample_size_calc(
         results[col] = {
             "sample_size_per_branch": sample_size,
             "population_percent_per_branch": pop_percent,
-            "population_size": len(df),
+            "number_of_clients_targeted": len(df),
         }
     return results
 
@@ -205,7 +205,7 @@ def z_or_t_ind_sample_size_calc(
         results[col] = {
             "sample_size_per_branch": sample_size,
             "population_percent_per_branch": pop_percent,
-            "population_size": len(df),
+            "number_of_clients_targeted": len(df),
         }
     return results
 
@@ -336,7 +336,7 @@ def empirical_effect_size_sample_size_calc(
     }
 
     for k in size_dict.keys():
-        size_dict[k]["population_size"] = pop_size
+        size_dict[k]["number_of_clients_targeted"] = pop_size
         size_dict[k]["population_percent_per_branch"] = 100.0 * (
             size_dict[k]["sample_size_per_branch"] / pop_size
         )
@@ -399,7 +399,7 @@ def poisson_diff_solve_sample_size(
         results[col] = {
             "sample_size_per_branch": sample_size,
             "population_percent_per_branch": pop_percent,
-            "population_size": len(df),
+            "number_of_clients_targeted": len(df),
         }
     return results
 

--- a/src/mozanalysis/frequentist_stats/sample_size.py
+++ b/src/mozanalysis/frequentist_stats/sample_size.py
@@ -2,16 +2,23 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import attr
+from typing import List, Union, Dict, Callable, Optional
+from datetime import datetime, timedelta
+
+from mozanalysis.bq import BigQueryContext
+from mozanalysis.experiment import TimeSeriesResult
+from mozanalysis.metrics import Metric
+from mozanalysis.segments import Segment
+from mozanalysis.sizing import HistoricalTarget
+from mozanalysis.utils import add_days
+
 from scipy.stats import norm
 from math import pi
 from statsmodels.stats.power import tt_ind_solve_power, zt_ind_solve_power
-from mozanalysis.bq import BigQueryContext
-from mozanalysis.experiment import TimeSeriesResult
 from statsmodels.stats.proportion import samplesize_proportions_2indep_onetail
 import numpy as np
 import pandas as pd
-from mozanalysis.metrics import Metric
-from typing import List, Union, Dict
 import matplotlib.pyplot as plt
 
 
@@ -134,8 +141,8 @@ def difference_of_proportions_sample_size_calc(
         pop_percent = 100.0 * (sample_size / len(df))
         results[col] = {
             "sample_size_per_branch": sample_size,
-            "number_of_clients_targeted": len(df),
             "population_percent_per_branch": pop_percent,
+            "population_size": len(df),
         }
     return results
 
@@ -197,8 +204,8 @@ def z_or_t_ind_sample_size_calc(
         pop_percent = 100.0 * (sample_size / len(df))
         results[col] = {
             "sample_size_per_branch": sample_size,
-            "number_of_clients_targeted": len(df),
             "population_percent_per_branch": pop_percent,
+            "population_size": len(df),
         }
     return results
 
@@ -329,12 +336,12 @@ def empirical_effect_size_sample_size_calc(
     }
 
     for k in size_dict.keys():
-        size_dict[k]["number_of_clients_targeted"] = pop_size
+        size_dict[k]["population_size"] = pop_size
         size_dict[k]["population_percent_per_branch"] = 100.0 * (
             size_dict[k]["sample_size_per_branch"] / pop_size
         )
 
-    return size_dict
+    return size_dict  # TODO: add option to return a DataFrame
 
 
 def poisson_diff_solve_sample_size(
@@ -391,7 +398,86 @@ def poisson_diff_solve_sample_size(
         pop_percent = 100.0 * (sample_size / len(df))
         results[col] = {
             "sample_size_per_branch": sample_size,
-            "number_of_clients_targeted": len(df),
             "population_percent_per_branch": pop_percent,
+            "population_size": len(df),
         }
     return results
+
+
+def variable_enrollment_length_sample_size_calc(
+    bq_context: BigQueryContext,
+    start_date: Union[str, datetime],
+    max_enrollment_days: int,
+    analysis_length: int,
+    metric_list: List[Metric],
+    target_list: List[Segment],
+    variable_window_length: int = 7,
+    experiment_name: str = "",
+    app_id: Optional[str] = "",
+    to_pandas: bool = True,
+    **sizing_kwargs,
+):
+    if variable_window_length > max_enrollment_days:
+        raise ValueError(
+            "Enrollment window length is larger than the max enrollment length."
+        )
+
+    ht = HistoricalTarget(
+        start_date=start_date,
+        analysis_length=analysis_length,
+        num_dates_enrollment=max_enrollment_days,
+        experiment_name=experiment_name,
+        app_id=app_id,
+    )
+
+    df = ht.get_single_window_data(
+        bq_context=bq_context, metric_list=metric_list, target_list=target_list
+    )
+
+    def _get_time_intervals(start_date: Union[str, datetime], interval: int):
+
+        if isinstance(start_date, str):
+            start_date = datetime.strptime(start_date, "%Y-%m-%d")
+
+        date = start_date + timedelta(interval - 1)
+        date_map = {0: date.date()}
+        i = 1
+        while date < start_date + timedelta(days=(max_enrollment_days - 1)):
+            date = date + timedelta(interval)
+            date_map[i] = date.date()
+            i += 1
+
+        date_map[i - 1] = df["enrollment_date"].max()
+        return date_map
+
+    date_intervals = _get_time_intervals(start_date, variable_window_length)
+
+    def _for_interval_sample_size_calculation(i):
+
+        df_interval = df.loc[df["enrollment_date"] < date_intervals[i]]
+        res = z_or_t_ind_sample_size_calc(
+            df=df_interval, metrics_list=metric_list, test="t", **sizing_kwargs
+        )
+        final_res = {}
+        for key in res.keys():
+            final_res[key] = {
+                "enrollment_end_date": date_intervals[i],
+                **res[key],
+            }
+
+        return final_res
+
+    results_dict = {}
+    for m in metric_list:
+        results_dict[m.name] = []
+
+    for i in range(len(date_intervals)):
+        res = _for_interval_sample_size_calculation(i)
+        for m in metric_list:
+            results_dict[m.name].append(res[m.name])
+
+    if to_pandas:
+        for m in results_dict.keys():
+            results_dict[m] = pd.DataFrame(results_dict[m])
+
+    return results_dict

--- a/src/mozanalysis/sizing.py
+++ b/src/mozanalysis/sizing.py
@@ -481,7 +481,7 @@ class HistoricalTarget:
             if i != 0:
                 target_joins.append(
                     """
-                    LEFT JOIN ds_{i}
+                    INNER JOIN ds_{i}
                         ON ds_{i}.client_id = ds_0.client_id
                         AND ds_{i}.target_first_date <= ds_0.target_last_date
                         AND ds_{i}.target_last_date >= ds_0.target_first_date

--- a/src/mozanalysis/utils.py
+++ b/src/mozanalysis/utils.py
@@ -6,6 +6,7 @@ import hashlib
 from functools import reduce
 
 import numpy as np
+from typing import Union, List
 
 
 def all_(l):
@@ -86,3 +87,39 @@ def filter_outliers(branch_data, threshold_quantile):
 def hash_ish(string, hex_chars=12):
     """Return a crude hash of a string."""
     return hashlib.sha256(string.encode("utf-8")).hexdigest()[:hex_chars]
+
+
+def get_time_intervals(
+    start_date: Union[str, datetime.datetime],
+    interval: int,
+    max_num_dates_enrollment: int,
+) -> List[datetime.datetime]:
+    """Use a start date and create end dates for enrollment intervals.
+    Used to generate intervals of enrollment to calculate metrics over
+    variable enrollment lengths.
+
+    Args:
+        start_date: First date of enrollment for sizing job.
+        interval: Number of days to increment the enrollment end date by.
+        max_num_dates_enrollment: Ceiling for the length of the enrollment
+            period.
+
+    Returns:
+        date_list: List of dates where variable enrollment windows will
+            end.
+    """
+
+    if isinstance(start_date, str):
+        start_date = datetime.datetime.strptime(start_date, "%Y-%m-%d")
+
+    date = start_date + datetime.timedelta(interval - 1)
+    date_list = [date.date()]
+    last_enrollment_date = start_date + datetime.timedelta(
+        days=(max_num_dates_enrollment - 1)
+    )
+    while date < last_enrollment_date:
+        date = date + datetime.timedelta(interval)
+        date_list.append(date.date())
+
+    date_list[len(date_list) - 1] = last_enrollment_date.date()
+    return date_list

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,5 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))
 
 
 def pytest_configure():
-
     logger = logging.getLogger("py4j")
     logger.setLevel(logging.ERROR)

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -31,7 +31,6 @@ def test_multiple_datasource():
 
 
 def test_query_not_detectably_malformed():
-
     test_target = HistoricalTarget("test_targ", "2022-01-01", 7, 3)
 
     tl = TimeLimits.for_single_analysis_window(
@@ -55,7 +54,6 @@ def test_query_not_detectably_malformed():
 
 
 def test_megaquery_not_detectably_malformed():
-
     test_target = HistoricalTarget("test_targ", "2022-01-01", 7, 3)
 
     tl = TimeLimits.for_single_analysis_window(


### PR DESCRIPTION
- Renames the results for sample size calc to make explicit that sizes are per branch of a study.
- Fixes joins for creating targets to use INNER rather than LEFT joins.