### PR TITLE
Change branch key for normandy exposures

### DIFF
--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -625,7 +625,7 @@ class Experiment:
         return """
         SELECT
             e.client_id,
-            `mozfun.map.get_key`(e.event_map_values, 'branch')
+            `mozfun.map.get_key`(e.event_map_values, 'branchSlug')
                 AS branch,
             MIN(e.submission_date) AS enrollment_date,
             COUNT(e.submission_date) AS num_enrollment_events


### PR DESCRIPTION
Normandy exposure events ([JS source]( https://searchfox.org/mozilla-central/source/toolkit/components/nimbus/ExperimentAPI.jsm#317) and [C++ source](https://searchfox.org/mozilla-central/source/toolkit/components/nimbus/lib/NimbusFeatures.cpp#199)) use `branchSlug` not `branch` for exposures, this is to correct the exposure query for desktop experiments