### PR TITLE
Move sizing analysis window

### DIFF
--- a/src/mozanalysis/sizing.py
+++ b/src/mozanalysis/sizing.py
@@ -183,7 +183,7 @@ class HistoricalTarget:
             time_limits = TimeLimits.for_single_analysis_window(
                 self.start_date,
                 last_date_full_data,
-                0,
+                1,
                 self.analysis_length,
                 self.num_dates_enrollment,
             )


### PR DESCRIPTION
Before, metrics collection for analysis began on the day of enrollment of a client for sample size calculation. This shifts the window to collect to 1 day after enrollment.