### PR TITLE
Remove parens in metric query

### DIFF
--- a/src/mozanalysis/metrics/__init__.py
+++ b/src/mozanalysis/metrics/__init__.py
@@ -105,8 +105,8 @@ class DataSource:
         else:
             return """(
                 SELECT *
-                FROM ({from_expr}) base
-                WHERE ({slug_expr})
+                FROM {from_expr} base
+                WHERE {slug_expr}
             )""".format(
                 from_expr=from_expr,
                 slug_expr=self.experiments_column_expr_base.format(


### PR DESCRIPTION
This was causing `Syntax error: Expected keyword JOIN but got ")"`