### PR TITLE
Ad click rate

### DIFF
--- a/src/mozanalysis/frequentist_stats/bootstrap.py
+++ b/src/mozanalysis/frequentist_stats/bootstrap.py
@@ -27,8 +27,8 @@ def compare_branches(
     Args:
         df: a pandas DataFrame of queried experiment data in the
             standard format (see ``mozanalysis.experiment``).
-        col_label (str): Label for the df column contaning the metric
-            to be analyzed.
+        col_label (str or list): Label for the df column contaning the metric
+            to be analyzed. If a list, labels for the multiple metrics to be analyzed.
         ref_branch_label (str, optional): String in ``df['branch']`` that
             identifies the branch with respect to which we want to
             calculate uplifts - usually the control branch.
@@ -115,7 +115,7 @@ def bootstrap_one_branch(
     of the outputs of ``stat_fn``.
 
     Args:
-        data: The data as a list, 1D numpy array, or pandas Series
+        data: The data as a 1D numpy array, pandas series, or pandas dataframe.
         stat_fn: Either a function that aggregates each resampled
             population to a scalar (e.g. the default value ``np.mean``
             lets you bootstrap means), or a function that aggregates
@@ -150,7 +150,7 @@ def get_bootstrap_samples(
     Do the resampling in parallel over the cluster.
 
     Args:
-        data: The data as a list, 1D numpy array, or pandas series
+        data: The data as a 1D numpy array, pandas series, or pandas dataframe.
         stat_fn: Either a function that aggregates each resampled
             population to a scalar (e.g. the default value ``np.mean``
             lets you bootstrap means), or a function that aggregates

--- a/src/mozanalysis/utils.py
+++ b/src/mozanalysis/utils.py
@@ -58,7 +58,7 @@ def date_sub(date_string_l, date_string_r):
 
 
 def filter_outliers(branch_data, threshold_quantile):
-    """Return branch_data with outliers removed.
+    """Return branch_data with outliers capped.
 
     N.B. `branch_data` is for an individual branch: if you do it for
     the entire experiment population in whole, then you may bias the
@@ -66,11 +66,11 @@ def filter_outliers(branch_data, threshold_quantile):
 
     Args:
         branch_data: Data for one branch as a 1D ndarray or similar.
-        threshold_quantile (float): Discard outliers above this
-            quantile.
+        threshold_quantile (float): Sets outliers above this
+            quantile equal to the value of this quantile.
 
     Returns:
-        The subset of branch_data that was at or below the threshold
+        branch_data with values capped at or below the threshold
         quantile.
     """
     if threshold_quantile > 1 or threshold_quantile < 0.5:

--- a/src/mozanalysis/utils.py
+++ b/src/mozanalysis/utils.py
@@ -64,9 +64,6 @@ def filter_outliers(branch_data, threshold_quantile):
     the entire experiment population in whole, then you may bias the
     results.
 
-    TODO: here we remove outliers - should we have an option or
-    default to cap them instead?
-
     Args:
         branch_data: Data for one branch as a 1D ndarray or similar.
         threshold_quantile (float): Discard outliers above this
@@ -79,9 +76,10 @@ def filter_outliers(branch_data, threshold_quantile):
     if threshold_quantile > 1 or threshold_quantile < 0.5:
         raise ValueError("'threshold_quantile' should be close to, and <= 1")
 
-    branch_data = np.sort(branch_data)
-    threshold_index = int(branch_data.shape[-1] * threshold_quantile)
-    return branch_data[..., :threshold_index]
+    min_threshold = np.min(branch_data, axis=0)
+    max_threshold = np.quantile(branch_data, threshold_quantile, axis=0)
+
+    return np.clip(branch_data, min_threshold, max_threshold)
 
 
 def hash_ish(string, hex_chars=12):

--- a/src/mozanalysis/utils.py
+++ b/src/mozanalysis/utils.py
@@ -79,9 +79,9 @@ def filter_outliers(branch_data, threshold_quantile):
     if threshold_quantile > 1 or threshold_quantile < 0.5:
         raise ValueError("'threshold_quantile' should be close to, and <= 1")
 
-    threshold_val = np.quantile(branch_data, threshold_quantile)
-
-    return branch_data[branch_data <= threshold_val]
+    branch_data = np.sort(branch_data)
+    threshold_index = int(branch_data.shape[-1] * threshold_quantile)
+    return branch_data[..., :threshold_index]
 
 
 def hash_ish(string, hex_chars=12):

--- a/tests/frequentist_stats/test_bootstrap.py
+++ b/tests/frequentist_stats/test_bootstrap.py
@@ -201,8 +201,9 @@ def test_compare_branches_multistat():
 
 
 def test_compare_branches_multiple_metrics():
-    # Dummy data: Create 2 branches with the same data. Expect no stat sig difference.
-    # The denominator values are 10x the numerator values. Expect the statistic to be ~0.1.
+    # Dummy data: Create 2 branches with the same data. Expect no stat sig
+    # difference. The denominator values are 10x the numerator values.
+    # Expect the statistic to be ~0.1.
     n = 10**3
     df = pd.DataFrame(
         {

--- a/tests/frequentist_stats/test_bootstrap.py
+++ b/tests/frequentist_stats/test_bootstrap.py
@@ -211,20 +211,20 @@ def test_compare_branches_multiple_metrics():
     )
 
     def custom_stat_fn(data):
-        return np.sum(data[0, :]) / np.sum(data[1, :])
+        return np.sum(data[:, 0]) / np.sum(data[:, 1])
 
     res = mafsb.compare_branches(
         df,
         ["ad_click", "sap"],
         stat_fn=custom_stat_fn,
-        num_samples=10**4,
+        num_samples=50,
         threshold_quantile=0.9,
     )
-    assert res["individual"]["control"].loc["mean"] == pytest.approx(0.1, rel=1e-1)
-    assert res["individual"]["treatment"].loc["mean"] == pytest.approx(0.1, rel=1e-1)
+    assert res["individual"]["control"].loc["mean"] == pytest.approx(0.1, rel=1e-5)
+    assert res["individual"]["treatment"].loc["mean"] == pytest.approx(0.1, rel=1e-5)
     assert res["comparative"]["treatment"][("rel_uplift", "exp")] == pytest.approx(
-        0, rel=1e-1
+        0, rel=1e-5
     )
     assert res["comparative"]["treatment"][("abs_uplift", "exp")] == pytest.approx(
-        0, rel=1e-1
+        0, rel=1e-5
     )

--- a/tests/frequentist_stats/test_bootstrap.py
+++ b/tests/frequentist_stats/test_bootstrap.py
@@ -201,6 +201,8 @@ def test_compare_branches_multistat():
 
 
 def test_compare_branches_multiple_metrics():
+    # Dummy data: Create 2 branches with the same data. Expect no stat sig difference.
+    # The denominator values are 10x the numerator values. Expect the statistic to be ~0.1.
     n = 10**3
     df = pd.DataFrame(
         {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -90,8 +90,8 @@ def test_filter_outliers():
     data = np.arange(100) + 1
 
     filtered = filter_outliers(data, 0.99)
-    assert len(filtered) == 99
-    assert filtered.max() == 99
+    assert len(filtered) == 100
+    assert filtered.max() == 99.01
     assert data.max() == 100
 
 


### PR DESCRIPTION
# Ad click rate

For the Google Trending experiment, we need this metric:
`ad click rate = (sum of ad clicks over all clients) / (sum of SAPs over all clients)`

This is a PR to allow Mozanalysis (and eventually Jetstream) to compute this metric.

# This PR changes Mozanalysis from truncating outliers to capping outliers.

I suggest this change because truncating outliers doesn't make sense when your metric involves multiple columns in a dataframe. For example, if we truncate outliers, then we have to answer questions like:

- if a client has an outlier value for searches, but not ad clicks, should we keep it?
- if a client has an outlier value for ad clicks, but not searches, should we keep it?

Capping avoids these problems (we keep all clients) and has been shown to have good theoretical properties when used with a mean: see[ Lugosi & Mendelson](https://arxiv.org/abs/1906.04280). (In the paper, they call it a "trimmed mean" instead of "capped mean" and they show that, as an estimator of the actual mean, the trimmed mean converges to the actual mean for heavy-tailed distributions as fast as possible / no slower than any other estimator.)

It is possible that a truncated mean also has the same good theoretical properties... I just haven't read anything that proves it. 

One advantage of truncation is that truncation may model our revenue more closely. For example, if outliers come from bots, we probably don't get paid for their searches and ad clicks, so truncation would more closely align the search metrics with revenue.

There is also [this analysis](https://mozilla-private.report/search-aa-tests/aa-tests.html) of 100 A/A tests where truncating and capping give similar results and capping is recommended.

I think the question of if we should change our defaults is open for debate.

