### PR TITLE
Fix #180: bug in sizing metrics query construction

### DIFF
--- a/src/mozanalysis/metrics/__init__.py
+++ b/src/mozanalysis/metrics/__init__.py
@@ -99,7 +99,7 @@ class DataSource:
                 ) from e
         from_expr = self._from_expr.format(dataset=effective_dataset)
 
-        if self.experiments_column_type is None:
+        if (self.experiments_column_type is None) or (experiment_slug is None):
             return from_expr
 
         else:


### PR DESCRIPTION
Adds a condition that returns from the `from_expr_for` method when no experiment slug is passed, as is always the case when constructing queries for experiment sizing.