### PR TITLE
[POC | not ready for merge] Speed up bootstrap using multiprocessing

### DIFF
--- a/tests/frequentist_stats/test_bootstrap.py
+++ b/tests/frequentist_stats/test_bootstrap.py
@@ -4,6 +4,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from time import time
 
 import mozanalysis.frequentist_stats.bootstrap as mafsb
 
@@ -70,6 +71,21 @@ def test_get_bootstrap_samples_multistat(stack_depth=0):
     elif (res["mean"] == np.mean(data)).any():
         # Re-roll the dice a few times to make sure this was a fluke.
         test_get_bootstrap_samples_multistat(stack_depth + 1)
+
+
+def test_get_bootstrap_samples_multiprocess():
+    t0 = time()
+    res1 = mafsb.get_bootstrap_samples(np.asarray(range(10**5)), processes=1)
+    t1 = time() - t0
+
+    t0 = time()
+    res2 = mafsb.get_bootstrap_samples(np.asarray(range(10**5)), processes=None)
+    t2 = time() - t0
+    assert t2 * 2 < t1  # The multiprocessing speedup is worth it if it's 2x faster.
+    # Not sure why we're getting different answers, but I believe this discrepancy is
+    # resolvable.
+    assert res1[0] == res2[0]
+    assert res1[1] == res2[1]
 
 
 def test_bootstrap_one_branch():


### PR DESCRIPTION
Trying out some things I learned at SciPy.

Locally, I'm seeing a 4-5x speed-up on the tests. I wonder what the speed-up would be in our production environments. 

I understand we're introducing a bit more non-determinism here, but I bet it's possible to make the difference small enough.

If this works, we should implement it for the Bayesian bootstrap too.

Other tips:
- This can probably be done with multithreading, which will use less memory and take less time.
- Another way to speed things up is to use [numba](https://numba.pydata.org/) on `stat_fn`'s that are not just simple compositions of numpy functions.

Tagging some folks for feedback on this proof of concept.