### PR TITLE
fix glean enrollments query with sample_id

### DIFF
--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -733,7 +733,7 @@ class Experiment:
                 AND e.category = "nimbus_events"
                 AND mozfun.map.get_key(e.extra, "experiment") = '{experiment_slug}'
                 AND e.name = 'enrollment'
-                AND e.sample_id < {sample_size}
+                AND sample_id < {sample_size}
             GROUP BY client_id, branch
             """.format(
             experiment_slug=self.experiment_slug,


### PR DESCRIPTION
Glean enrollments query uses `UNNEST(events.events)` as `e` instead of just `events` so we need to change the WHERE clause to remove the `e.` from `sample_id`.