### PR TITLE
fix category filter: add quotes to value

### DIFF
--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -871,7 +871,7 @@ class Experiment:
                 WHERE
                     DATE(events.submission_timestamp)
                     BETWEEN '{first_enrollment_date}' AND '{last_enrollment_date}'
-                    AND event.category = {event_category}
+                    AND event.category = '{event_category}'
                     AND mozfun.map.get_key(
                         event.extra,
                         "experiment") = '{experiment_slug}'


### PR DESCRIPTION
`2023.10.1` introduced a parameter for filtering on a passed category instead of a static string, but was missing quotes around the value. This PR fixes that.