### PR TITLE
Add loading for metrics & data sources defined in outcomes

### DIFF
--- a/docs/api/config.rst
+++ b/docs/api/config.rst
@@ -1,0 +1,9 @@
+:mod:`mozanalysis.config`
+-----------------------------
+
+.. automodule:: mozanalysis.config
+   :members:
+   :private-members: _ConfigLoader
+
+   .. autodata:: ConfigLoader
+

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -51,19 +51,19 @@ We start by instantiating our :class:`mozanalysis.experiment.Experiment` object:
 ``start_date`` is the ``submission_date`` of the first enrollment (``submission_date`` is in UTC). If you intended to study one week's worth of enrollments, then set ``num_dates_enrollment=8``: Normandy experiments typically go live in the evening UTC-time, so 8 days of data is a better approximation than 7.
 
 
-We now gather a list of who was enrolled in what branch and when, and try to quantify what happened to each client. In many cases, the metrics in which you're interested will already be in a metrics library, [Metric Hub](https://github.com/mozilla/metric-hub). If not, then you can define your own - see :meth:`mozanalysis.metrics.Metric` for examples - and ideally submit a PR to add them to Metric Hub for the next experiment. To load a Metric from Metric Hub, for example:
+We now gather a list of who was enrolled in what branch and when, and try to quantify what happened to each client. In many cases, the metrics in which you're interested will already be in a metrics library, `metric-hub <https://github.com/mozilla/metric-hub>`_. If not, then you can define your own---see :class:`mozanalysis.metrics.Metric` for examples---and ideally submit a PR to add them to metric-hub for the next experiment. To load a Metric from metric-hub, for example::
 
     from mozanalysis.config import ConfigLoader
     active_hours = ConfigLoader.get_metric(slug="active_hours", app_name="firefox_desktop")
 
-In this example, we'll compute four metrics from Metric Hub:
+In this example, we'll compute four metrics from metric-hub:
 
 * active hours
 * uri count
 * ad clicks
 * search count
 
-As it happens, the first three metrics all come from the ``clients_daily`` dataset, whereas "search count" comes from ``search_clients_daily``. These details are taken care of in the [Metric Hub definitions](https://github.com/mozilla/metric-hub/tree/main/definitions) so that we don't have to think about them here.
+As it happens, the first three metrics all come from the ``clients_daily`` dataset, whereas "search count" comes from ``search_clients_daily``. These details are taken care of in the `metric-hub definitions <https://github.com/mozilla/metric-hub/tree/main/definitions>`_ so that we don't have to think about them here.
 
 A metric must be computed over some `analysis window`, a period of time defined with respect to the enrollment date. We could use :meth:`mozanalysis.experiment.Experiment.get_single_window_data()` to compute our metrics over a specific analysis window. But here, let's create time series data: let's have an analysis window for each of the first three weeks of the experiment, and measure the data for each of these analysis windows::
 
@@ -81,7 +81,7 @@ A metric must be computed over some `analysis window`, a period of time defined 
 
 The first two arguments to :meth:`mozanalysis.experiment.Experiment.get_time_series_data()` should be clear by this point. ``last_date_full_data`` is the last date for which we want to use data. For a currently-running experiment, it would typically be yesterday's date (we have incomplete data for incomplete days!).
 
-Metrics are pulled in from [metric-hub](https://github.com/mozilla/metric-hub) based on the provided metric slugs.
+Metrics are pulled in from `metric-hub <https://github.com/mozilla/metric-hub>`_ based on the provided metric slugs.
 
 ``time_series_period`` can be ``'daily'``, ``'weekly'`` or ``'28_day'``. A ``'weekly'`` time series neatly sidesteps/masks weekly seasonality issues: most of the experiment subjects will enroll within a day of the experiment launching - typically a Tuesday, leading to ``'daily'`` time series reflecting a non-uniform convolution of the metrics' weekly seasonalities with the uneven enrollment numbers across the week.
 

--- a/src/mozanalysis/config.py
+++ b/src/mozanalysis/config.py
@@ -49,7 +49,7 @@ class _ConfigLoader:
     def get_metric(self, metric_slug: str, app_name: str):
         """Load a metric definition for the given app.
 
-        Returns a mozanalysis `Metric` instance.
+        Returns a :class:`mozanalysis.metrics.Metric` instance.
         """
         from mozanalysis.metrics import Metric
 
@@ -73,7 +73,7 @@ class _ConfigLoader:
     def get_data_source(self, data_source_slug: str, app_name: str):
         """Load a data source definition for the given app.
 
-        Returns a mozanalysis `DataSource` instance.
+        Returns a :class:`mozanalysis.metrics.DataSource` instance.
         """
         from mozanalysis.metrics import DataSource
 
@@ -99,7 +99,7 @@ class _ConfigLoader:
     def get_segment(self, segment_slug: str, app_name: str):
         """Load a segment definition for the given app.
 
-        Returns a mozanalysis `Segment` instance.
+        Returns a :class:`mozanalysis.segments.Segment` instance.
         """
         from mozanalysis.segments import Segment
 
@@ -122,7 +122,7 @@ class _ConfigLoader:
     def get_segment_data_source(self, data_source_slug: str, app_name: str):
         """Load a segment data source definition for the given app.
 
-        Returns a mozanalysis `SegmentDataSource` instance.
+        Returns a :class:`mozanalysis.segments.SegmentDataSource` instance.
         """
         from mozanalysis.segments import SegmentDataSource
 
@@ -149,7 +149,7 @@ class _ConfigLoader:
 
         Parametrized metrics are not supported, since they may not be defined outside of an experiment.
 
-        Returns a mozanalysis `Metric` instance.
+        Returns a :class:`mozanalysis.metrics.Metric` instance.
         """
         from mozanalysis.metrics import Metric
 
@@ -214,7 +214,7 @@ class _ConfigLoader:
     ):
         """Load a data source definition from an outcome defined for the given app.
 
-        Returns a mozanalysis `DataSource` instance.
+        Returns a :class:`mozanalysis.metrics.DataSource` instance.
         """
         from mozanalysis.metrics import DataSource
 

--- a/src/mozanalysis/config.py
+++ b/src/mozanalysis/config.py
@@ -65,7 +65,7 @@ class _ConfigLoader:
             .from_string(metric_definition.select_expression)
             .render(),
             friendly_name=metric_definition.friendly_name,
-            description=metric_definition.friendly_name,
+            description=metric_definition.description,
             data_source=self.get_data_source(
                 metric_definition.data_source.name, app_name
             ),

--- a/src/mozanalysis/config.py
+++ b/src/mozanalysis/config.py
@@ -5,12 +5,7 @@
 from typing import List, Optional
 from dataclasses import dataclass
 
-from jinja2 import UndefinedError
-
 from metric_config_parser.config import ConfigCollection
-from metric_config_parser.outcome import OutcomeSpec
-from metric_config_parser.data_source import DataSourceDefinition
-from metric_config_parser.metric import MetricDefinition
 
 METRIC_HUB_JETSTREAM_REPO = "https://github.com/mozilla/metric-hub/tree/main/jetstream"
 

--- a/src/mozanalysis/config.py
+++ b/src/mozanalysis/config.py
@@ -147,7 +147,8 @@ class _ConfigLoader:
     def get_outcome_metric(self, metric_slug: str, outcome_slug: str, app_name: str):
         """Load a metric definition from an outcome defined for the given app.
 
-        Parametrized metrics are not supported, since they may not be defined outside of an experiment.
+        Parametrized metrics are not supported, since they may not be defined outside
+        of an experiment.
 
         Returns a :class:`mozanalysis.metrics.Metric` instance.
         """
@@ -169,11 +170,13 @@ class _ConfigLoader:
         metric_definition = _get_metric_definition(outcome_spec, metric_slug)
         if metric_definition is None:
             raise Exception(
-                f"Could not find definition for metric {metric_slug} in outcome {outcome_slug}"
+                f"Could not find definition for metric {metric_slug}"
+                + f" in outcome {outcome_slug}"
             )
 
-        # Data source associated with the metric can either be defined in the outcome or in the
-        # general definition file for the app. Outcome definitions take precedence.
+        # Data source associated with the metric can either be defined in the outcome
+        # or in the general definition file for the app.
+        # Outcome definitions take precedence.
         try:
             data_source = self.get_outcome_data_source(
                 metric_definition.data_source.name, outcome_slug, app_name
@@ -183,7 +186,8 @@ class _ConfigLoader:
                 metric_definition.data_source.name, app_name
             )
 
-        # Functions used in templated metric definitions are defined both under `jetstream/` and at the top level.
+        # Functions used in templated metric definitions are defined both under
+        # `jetstream/` and at the top level.
         # Merge these with functions under `jetstream/` taking precedence.
         jinja_env = self.configs.get_env()
         jinja_env.globals.update(self.jetstream_configs.get_env().globals)
@@ -236,7 +240,8 @@ class _ConfigLoader:
         )
         if data_source_definition is None:
             raise Exception(
-                f"Could not find definition for data source {data_source_slug} in outcome {outcome_slug}"
+                f"Could not find definition for data source {data_source_slug}"
+                + f" in outcome {outcome_slug}"
             )
 
         return DataSource(

--- a/src/mozanalysis/config.py
+++ b/src/mozanalysis/config.py
@@ -4,7 +4,12 @@
 
 from typing import Optional
 
+from jinja2 import UndefinedError
+
 from metric_config_parser.config import ConfigCollection
+from metric_config_parser.outcome import OutcomeSpec
+from metric_config_parser.data_source import DataSourceDefinition
+from metric_config_parser.metric import MetricDefinition
 
 
 class _ConfigLoader:
@@ -15,6 +20,7 @@ class _ConfigLoader:
     """
 
     config_collection: Optional[ConfigCollection] = None
+    jetstream_config_collection: Optional[ConfigCollection] = None
 
     @property
     def configs(self) -> ConfigCollection:
@@ -27,7 +33,24 @@ class _ConfigLoader:
         self._configs = self.config_collection
         return self._configs
 
+    @property
+    def jetstream_configs(self) -> ConfigCollection:
+        configs = getattr(self, "_jetstream_configs", None)
+        if configs:
+            return configs
+
+        if self.jetstream_config_collection is None:
+            self.jetstream_config_collection = ConfigCollection.from_github_repo(
+                path="jetstream"
+            )
+        self._jetstream_configs = self.jetstream_config_collection
+        return self._jetstream_configs
+
     def get_metric(self, metric_slug: str, app_name: str):
+        """Load a metric definition for the given app.
+
+        Returns a mozanalysis `Metric` instance.
+        """
         from mozanalysis.metrics import Metric
 
         metric_definition = self.configs.get_metric_definition(metric_slug, app_name)
@@ -48,6 +71,10 @@ class _ConfigLoader:
         )
 
     def get_data_source(self, data_source_slug: str, app_name: str):
+        """Load a data source definition for the given app.
+
+        Returns a mozanalysis `DataSource` instance.
+        """
         from mozanalysis.metrics import DataSource
 
         data_source_definition = self.configs.get_data_source_definition(
@@ -70,6 +97,10 @@ class _ConfigLoader:
         )
 
     def get_segment(self, segment_slug: str, app_name: str):
+        """Load a segment definition for the given app.
+
+        Returns a mozanalysis `Segment` instance.
+        """
         from mozanalysis.segments import Segment
 
         segment_definition = self.configs.get_segment_definition(segment_slug, app_name)
@@ -89,6 +120,10 @@ class _ConfigLoader:
         )
 
     def get_segment_data_source(self, data_source_slug: str, app_name: str):
+        """Load a segment data source definition for the given app.
+
+        Returns a mozanalysis `SegmentDataSource` instance.
+        """
         from mozanalysis.segments import SegmentDataSource
 
         data_source_definition = self.configs.get_segment_data_source_definition(
@@ -106,6 +141,112 @@ class _ConfigLoader:
             window_end=data_source_definition.window_end,
             client_id_column=data_source_definition.client_id_column,
             submission_date_column=data_source_definition.submission_date_column,
+            default_dataset=data_source_definition.default_dataset,
+        )
+
+    def get_outcome_metric(self, metric_slug: str, outcome_slug: str, app_name: str):
+        """Load a metric definition from an outcome defined for the given app.
+
+        Parametrized metrics are not supported, since they may not be defined outside of an experiment.
+
+        Returns a mozanalysis `Metric` instance.
+        """
+        from mozanalysis.metrics import Metric
+
+        def _get_metric_definition(
+            spec: OutcomeSpec, slug: str
+        ) -> Optional[MetricDefinition]:
+            for m_slug, metric in spec.metrics.items():
+                if m_slug == slug:
+                    return metric
+            return None
+
+        outcome_spec = self.jetstream_configs.spec_for_outcome(
+            slug=outcome_slug, platform=app_name
+        )
+        if not outcome_spec:
+            raise Exception(f"Could not find definition for outcome {outcome_slug}")
+        metric_definition = _get_metric_definition(outcome_spec, metric_slug)
+        if metric_definition is None:
+            raise Exception(
+                f"Could not find definition for metric {metric_slug} in outcome {outcome_slug}"
+            )
+
+        # Data source associated with the metric can either be defined in the outcome or in the
+        # general definition file for the app. Outcome definitions take precedence.
+        try:
+            data_source = self.get_outcome_data_source(
+                metric_definition.data_source.name, outcome_slug, app_name
+            )
+        except Exception:
+            data_source = self.get_data_source(
+                metric_definition.data_source.name, app_name
+            )
+
+        # Functions used in templated metric definitions are defined both under `jetstream/` and at the top level.
+        # Merge these with functions under `jetstream/` taking precedence.
+        jinja_env = self.configs.get_env()
+        jinja_env.globals.update(self.jetstream_configs.get_env().globals)
+
+        try:
+            select_expr = jinja_env.from_string(
+                metric_definition.select_expression
+            ).render()
+        except UndefinedError as e:
+            if "parameters" in str(e):
+                raise NotImplementedError(
+                    "Parametrized outcome metrics are not supported"
+                )
+            else:
+                raise
+
+        return Metric(
+            name=metric_definition.name,
+            select_expr=select_expr,
+            friendly_name=metric_definition.friendly_name,
+            description=metric_definition.friendly_name,
+            data_source=data_source,
+            bigger_is_better=metric_definition.bigger_is_better,
+        )
+
+    def get_outcome_data_source(
+        self, data_source_slug: str, outcome_slug: str, app_name: str
+    ):
+        """Load a data source definition from an outcome defined for the given app.
+
+        Returns a mozanalysis `DataSource` instance.
+        """
+        from mozanalysis.metrics import DataSource
+
+        def _get_data_source_definition(
+            spec: OutcomeSpec, slug: str
+        ) -> Optional[DataSourceDefinition]:
+            for ds_slug, data_source in spec.data_sources.definitions.items():
+                if ds_slug == slug:
+                    return data_source
+            return None
+
+        outcome_spec = self.jetstream_configs.spec_for_outcome(
+            slug=outcome_slug, platform=app_name
+        )
+        if not outcome_spec:
+            raise Exception(f"Could not find definition for outcome {outcome_slug}")
+        data_source_definition = _get_data_source_definition(
+            outcome_spec, data_source_slug
+        )
+        if data_source_definition is None:
+            raise Exception(
+                f"Could not find definition for data source {data_source_slug} in outcome {outcome_slug}"
+            )
+
+        return DataSource(
+            name=data_source_definition.name,
+            from_expr=data_source_definition.from_expression,
+            client_id_column=data_source_definition.client_id_column,
+            submission_date_column=data_source_definition.submission_date_column,
+            experiments_column_type=None
+            if data_source_definition.experiments_column_type == "none"
+            else data_source_definition.experiments_column_type,
             default_dataset=data_source_definition.default_dataset,
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -71,9 +71,9 @@ def test_unknown_segment_data_source_fails():
 
 
 def test_get_outcome_metric_outcome_data_source():
-    m = ConfigLoader.get_outcome_metric(
-        "cert_error_page_loaded", "networking", "firefox_desktop"
-    )
+    m = ConfigLoader.with_configs_from(
+        ["https://github.com/mozilla/metric-hub/tree/main/jetstream"]
+    ).get_outcome_metric("cert_error_page_loaded", "networking", "firefox_desktop")
     assert isinstance(m, Metric)
     assert m.name == "cert_error_page_loaded"
     assert m.friendly_name
@@ -83,9 +83,9 @@ def test_get_outcome_metric_outcome_data_source():
 
 
 def test_get_outcome_metric_general_data_source():
-    m = ConfigLoader.get_outcome_metric(
-        "urlbar_search_count", "firefox_suggest", "firefox_desktop"
-    )
+    m = ConfigLoader.with_configs_from(
+        ["https://github.com/mozilla/metric-hub/tree/main/jetstream"]
+    ).get_outcome_metric("urlbar_search_count", "firefox_suggest", "firefox_desktop")
     assert isinstance(m, Metric)
     assert m.name == "urlbar_search_count"
     assert m.friendly_name
@@ -96,27 +96,31 @@ def test_get_outcome_metric_general_data_source():
 
 def test_get_parametrized_outcome_metric_fails():
     with pytest.raises(NotImplementedError):
-        ConfigLoader.get_outcome_metric(
+        ConfigLoader.with_configs_from(
+            ["https://github.com/mozilla/metric-hub/tree/main/jetstream"]
+        ).get_outcome_metric(
             "spotlight_impressions", "spotlight_engagement", "firefox_desktop"
         )
 
 
 def test_outcome_unknown_metric_fails():
     with pytest.raises(Exception):
-        ConfigLoader.get_outcome_metric("fake_metric", "networking", "firefox_desktop")
+        ConfigLoader.with_configs_from(
+            ["https://github.com/mozilla/metric-hub/tree/main/jetstream"]
+        ).get_outcome_metric("fake_metric", "networking", "firefox_desktop")
 
 
 def test_unknown_outcome_metric_fails():
     with pytest.raises(Exception):
-        ConfigLoader.get_outcome_metric(
-            "fake_metric", "fake_outcome", "firefox_desktop"
-        )
+        ConfigLoader.with_configs_from(
+            ["https://github.com/mozilla/metric-hub/tree/main/jetstream"]
+        ).get_outcome_metric("fake_metric", "fake_outcome", "firefox_desktop")
 
 
 def test_get_outcome_data_source():
-    d = ConfigLoader.get_outcome_data_source(
-        "events_certerror", "networking", "firefox_desktop"
-    )
+    d = ConfigLoader.with_configs_from(
+        ["https://github.com/mozilla/metric-hub/tree/main/jetstream"]
+    ).get_outcome_data_source("events_certerror", "networking", "firefox_desktop")
     assert isinstance(d, DataSource)
     assert d.name == "events_certerror"
     assert d.submission_date_column == "submission_date"
@@ -125,13 +129,13 @@ def test_get_outcome_data_source():
 
 def test_outcome_unknown_data_source():
     with pytest.raises(Exception):
-        ConfigLoader.get_outcome_data_source(
-            "fake_data_source", "networking", "firefox_desktop"
-        )
+        ConfigLoader.with_configs_from(
+            ["https://github.com/mozilla/metric-hub/tree/main/jetstream"]
+        ).get_outcome_data_source("fake_data_source", "networking", "firefox_desktop")
 
 
 def test_unknown_outcome_data_source():
     with pytest.raises(Exception):
-        ConfigLoader.get_outcome_data_source(
-            "fake_data_source", "fake_outcome", "firefox_desktop"
-        )
+        ConfigLoader.with_configs_from(
+            ["https://github.com/mozilla/metric-hub/tree/main/jetstream"]
+        ).get_outcome_data_source("fake_data_source", "fake_outcome", "firefox_desktop")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -71,21 +71,20 @@ def test_unknown_segment_data_source_fails():
 
 
 def test_get_outcome_metric_outcome_data_source():
-    m = ConfigLoader.with_configs_from(
-        ["https://github.com/mozilla/metric-hub/tree/main/jetstream"]
-    ).get_outcome_metric("cert_error_page_loaded", "networking", "firefox_desktop")
+    m = ConfigLoader.get_outcome_metric(
+        "cert_error_page_loaded", "networking", "firefox_desktop"
+    )
     assert isinstance(m, Metric)
     assert m.name == "cert_error_page_loaded"
     assert m.friendly_name
-    assert m.description
     assert m.data_source
     sql_lint(m.select_expr)
 
 
 def test_get_outcome_metric_general_data_source():
-    m = ConfigLoader.with_configs_from(
-        ["https://github.com/mozilla/metric-hub/tree/main/jetstream"]
-    ).get_outcome_metric("urlbar_search_count", "firefox_suggest", "firefox_desktop")
+    m = ConfigLoader.get_outcome_metric(
+        "urlbar_search_count", "firefox_suggest", "firefox_desktop"
+    )
     assert isinstance(m, Metric)
     assert m.name == "urlbar_search_count"
     assert m.friendly_name
@@ -95,32 +94,33 @@ def test_get_outcome_metric_general_data_source():
 
 
 def test_get_parametrized_outcome_metric_fails():
-    with pytest.raises(NotImplementedError):
-        ConfigLoader.with_configs_from(
-            ["https://github.com/mozilla/metric-hub/tree/main/jetstream"]
-        ).get_outcome_metric(
-            "spotlight_impressions", "spotlight_engagement", "firefox_desktop"
-        )
+    m = ConfigLoader.get_outcome_metric(
+        "spotlight_impressions", "spotlight_engagement", "firefox_desktop"
+    )
+    assert isinstance(m, Metric)
+    assert m.name == "spotlight_impressions"
+    assert m.friendly_name
+    assert m.description
+    assert m.data_source
+    sql_lint(m.select_expr)
 
 
 def test_outcome_unknown_metric_fails():
     with pytest.raises(Exception):
-        ConfigLoader.with_configs_from(
-            ["https://github.com/mozilla/metric-hub/tree/main/jetstream"]
-        ).get_outcome_metric("fake_metric", "networking", "firefox_desktop")
+        ConfigLoader.get_outcome_metric("fake_metric", "networking", "firefox_desktop")
 
 
 def test_unknown_outcome_metric_fails():
     with pytest.raises(Exception):
-        ConfigLoader.with_configs_from(
-            ["https://github.com/mozilla/metric-hub/tree/main/jetstream"]
-        ).get_outcome_metric("fake_metric", "fake_outcome", "firefox_desktop")
+        ConfigLoader.get_outcome_metric(
+            "fake_metric", "fake_outcome", "firefox_desktop"
+        )
 
 
 def test_get_outcome_data_source():
-    d = ConfigLoader.with_configs_from(
-        ["https://github.com/mozilla/metric-hub/tree/main/jetstream"]
-    ).get_outcome_data_source("events_certerror", "networking", "firefox_desktop")
+    d = ConfigLoader.get_outcome_data_source(
+        "events_certerror", "networking", "firefox_desktop"
+    )
     assert isinstance(d, DataSource)
     assert d.name == "events_certerror"
     assert d.submission_date_column == "submission_date"
@@ -129,13 +129,13 @@ def test_get_outcome_data_source():
 
 def test_outcome_unknown_data_source():
     with pytest.raises(Exception):
-        ConfigLoader.with_configs_from(
-            ["https://github.com/mozilla/metric-hub/tree/main/jetstream"]
-        ).get_outcome_data_source("fake_data_source", "networking", "firefox_desktop")
+        ConfigLoader.get_outcome_data_source(
+            "fake_data_source", "networking", "firefox_desktop"
+        )
 
 
 def test_unknown_outcome_data_source():
     with pytest.raises(Exception):
-        ConfigLoader.with_configs_from(
-            ["https://github.com/mozilla/metric-hub/tree/main/jetstream"]
-        ).get_outcome_data_source("fake_data_source", "fake_outcome", "firefox_desktop")
+        ConfigLoader.get_outcome_data_source(
+            "fake_data_source", "fake_outcome", "firefox_desktop"
+        )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,137 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from cheap_lint import sql_lint
+from mozanalysis.config import ConfigLoader
+from mozanalysis.metrics import DataSource, Metric
+from mozanalysis.segments import Segment, SegmentDataSource
+
+
+def test_get_metric():
+    m = ConfigLoader.get_metric("active_hours", "firefox_desktop")
+    assert isinstance(m, Metric)
+    assert m.name == "active_hours"
+    assert m.friendly_name
+    assert m.description
+    assert m.data_source
+    sql_lint(m.select_expr)
+
+
+def test_unknown_metric_fails():
+    with pytest.raises(Exception):
+        ConfigLoader.get_metric("fake_metric", "firefox_desktop")
+
+
+def test_get_data_source():
+    d = ConfigLoader.get_data_source("clients_daily", "firefox_desktop")
+    assert isinstance(d, DataSource)
+    assert d.name == "clients_daily"
+    assert d.client_id_column == "client_id"
+    assert d.submission_date_column == "submission_date"
+    sql_lint(d.from_expr_for("dataset"))
+
+
+def test_unknown_data_source_fails():
+    with pytest.raises(Exception):
+        ConfigLoader.get_data_source("fake_data_source", "firefox_desktop")
+
+
+def test_get_segment():
+    s = ConfigLoader.get_segment("suggest", "firefox_desktop")
+    assert isinstance(s, Segment)
+    assert s.name == "suggest"
+    assert s.data_source
+    sql_lint(s.select_expr)
+
+
+def test_unknown_segment_fails():
+    with pytest.raises(Exception):
+        ConfigLoader.get_segment("fake_segment", "firefox_desktop")
+
+
+def test_get_segment_data_source():
+    s = ConfigLoader.get_segment_data_source("clients_last_seen", "firefox_desktop")
+    assert isinstance(s, SegmentDataSource)
+    assert s.name == "clients_last_seen"
+    assert s.client_id_column == "client_id"
+    assert s.submission_date_column == "submission_date"
+    assert s.window_start == 0
+    assert s.window_end == 0
+    sql_lint(s.from_expr_for("dataset"))
+
+
+def test_unknown_segment_data_source_fails():
+    with pytest.raises(Exception):
+        ConfigLoader.get_segment_data_source(
+            "fake_segment_data_source", "firefox_desktop"
+        )
+
+
+def test_get_outcome_metric_outcome_data_source():
+    m = ConfigLoader.get_outcome_metric(
+        "cert_error_page_loaded", "networking", "firefox_desktop"
+    )
+    assert isinstance(m, Metric)
+    assert m.name == "cert_error_page_loaded"
+    assert m.friendly_name
+    assert m.description
+    assert m.data_source
+    sql_lint(m.select_expr)
+
+
+def test_get_outcome_metric_general_data_source():
+    m = ConfigLoader.get_outcome_metric(
+        "urlbar_search_count", "firefox_suggest", "firefox_desktop"
+    )
+    assert isinstance(m, Metric)
+    assert m.name == "urlbar_search_count"
+    assert m.friendly_name
+    assert m.description
+    assert m.data_source
+    sql_lint(m.select_expr)
+
+
+def test_get_parametrized_outcome_metric_fails():
+    with pytest.raises(NotImplementedError):
+        ConfigLoader.get_outcome_metric(
+            "spotlight_impressions", "spotlight_engagement", "firefox_desktop"
+        )
+
+
+def test_outcome_unknown_metric_fails():
+    with pytest.raises(Exception):
+        ConfigLoader.get_outcome_metric("fake_metric", "networking", "firefox_desktop")
+
+
+def test_unknown_outcome_metric_fails():
+    with pytest.raises(Exception):
+        ConfigLoader.get_outcome_metric(
+            "fake_metric", "fake_outcome", "firefox_desktop"
+        )
+
+
+def test_get_outcome_data_source():
+    d = ConfigLoader.get_outcome_data_source(
+        "events_certerror", "networking", "firefox_desktop"
+    )
+    assert isinstance(d, DataSource)
+    assert d.name == "events_certerror"
+    assert d.submission_date_column == "submission_date"
+    sql_lint(d.from_expr_for("dataset"))
+
+
+def test_outcome_unknown_data_source():
+    with pytest.raises(Exception):
+        ConfigLoader.get_outcome_data_source(
+            "fake_data_source", "networking", "firefox_desktop"
+        )
+
+
+def test_unknown_outcome_data_source():
+    with pytest.raises(Exception):
+        ConfigLoader.get_outcome_data_source(
+            "fake_data_source", "fake_outcome", "firefox_desktop"
+        )


### PR DESCRIPTION
This will be useful when we want to use metrics or data sources defined in metric-hub outcomes in sizing or other ad-hoc calculations. The current workflow is to copy-paste the metric definition. `ConfigLoader` is now the main way that metric-hub configs are accessed by data scientists working in notebooks.

Other updates:
- Add tests for config.py
  * Currently this relies on pulling specific configs from metric-hub, which could change in the future. The "proper" way would be to mock a version of metric-hub in this repo, but I wasn't sure that was necessary at this point.
- Add API docs for config.py
- Minor cleanup of markup in guide doc page
- Fix setting description for metrics