### PR TITLE
Fix get_quantile_bootstrap_samples index errors

### DIFF
--- a/src/mozanalysis/frequentist_stats/bootstrap.py
+++ b/src/mozanalysis/frequentist_stats/bootstrap.py
@@ -284,7 +284,7 @@ def get_quantile_bootstrap_samples(
     sample_size = data.shape[0]
     samples = {
         f"{quantile:.1}": data[
-            np.random.binomial(sample_size + 1, quantile, num_samples)
+            np.random.binomial(sample_size - 1, quantile, num_samples)
         ]
         for quantile in quantiles_of_interest
     }

--- a/tests/frequentist_stats/test_bootstrap.py
+++ b/tests/frequentist_stats/test_bootstrap.py
@@ -286,3 +286,13 @@ def test_compare_branches_quantiles():
         equal_nan=True,
     )
     assert arr_eq.all(), f"branch {branch} absolute differences differ"
+
+
+def test_get_quantile_bootstrap_samples():
+    res = mafsb.get_quantile_bootstrap_samples(
+        np.array([3.0, 3.0, 3.0]), quantiles_of_interest=[0.5], num_samples=10
+    )
+    assert res.shape == (10, 1)
+
+    assert res["0.5"][0] == 3.0
+    assert res["0.5"][1] == 3.0


### PR DESCRIPTION
To fix the errors like `Error while computing statistic deciles for metric default_browser_card_go_to_settings_pressed: index 30 is out of bounds for axis 0 with size 30`