### PR TITLE
Expand empirical effect size results

### DIFF
--- a/tests/frequentist_stats/test_sample_size_calc.py
+++ b/tests/frequentist_stats/test_sample_size_calc.py
@@ -1,11 +1,35 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from dataclasses import dataclass
+
 import numpy as np
 import pandas as pd
+import pytest
 
-from mozanalysis.frequentist_stats.sample_size import z_or_t_ind_sample_size_calc
+from mozanalysis.frequentist_stats.sample_size import (
+    z_or_t_ind_sample_size_calc,
+    empirical_effect_size_sample_size_calc,
+)
 from mozanalysis.metrics.desktop import search_clients_daily, uri_count
+
+
+@pytest.fixture
+def fake_ts_result():
+    class FakeTimeSeriesResult:
+        def get_aggregated_data(self, metric_list, aggregate_function, **kwargs):
+            periods = [0, 7, 14]
+            if aggregate_function == "AVG":
+                values = [5, 2, 1]
+            else:
+                values = [1, 2, 1]
+
+            df = pd.DataFrame({"analysis_window_start": periods})
+            for m in metric_list:
+                df[m.name] = values
+            return df, 1000
+
+    return FakeTimeSeriesResult()
 
 
 def test_sample_size_calc_desktop():
@@ -22,3 +46,31 @@ def test_sample_size_calc_desktop():
 
     assert res[search_clients_daily.name]["sample_size_per_branch"] > 1000000
     assert res[uri_count.name]["sample_size_per_branch"] > 1000000
+
+
+def test_empirical_effect_size_sample_size_calc(fake_ts_result):
+    @dataclass
+    class FakeMetric:
+        name: str
+
+    metric_list = [FakeMetric(name="metric1"), FakeMetric(name="metric2")]
+
+    result = empirical_effect_size_sample_size_calc(
+        res=fake_ts_result, bq_context=None, metric_list=metric_list
+    )
+
+    assert len(result) == 2
+    for m in ["metric1", "metric2"]:
+        r = result[m]
+        assert r["effect_size"]["value"] == 3
+        assert r["effect_size"]["period_start_day"] == 7
+        assert r["mean"]["value"] == 5
+        assert r["mean"]["period_start_day"] == 0
+        assert r["std_dev"]["value"] == 2
+        assert r["std_dev"]["period_start_day"] == 7
+        assert r["relative_effect_size"] == 0.6
+        assert r["number_of_clients_targeted"] == 1000
+        np.testing.assert_allclose(r["sample_size_per_branch"], 8.44, atol=0.01)
+        np.testing.assert_allclose(
+            r["population_percent_per_branch"], 0.844, atol=0.001
+        )


### PR DESCRIPTION
This adds metric mean value and relative effect size to the empirical sizing output dict.

Additionally:
- Simplify the code to build the result dict
- Add a test for empirical sizing