### PR TITLE
Improve readability of sizing functions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 
 tests_require = [
     "mock",
-    "pytest",
+    "pytest<7",
     "pytest-black",
     "pytest-cov",
     "pytest-timeout",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 
 tests_require = [
     "mock",
-    "pytest<7",
+    "pytest",
     "pytest-black",
     "pytest-cov",
     "pytest-timeout",

--- a/src/mozanalysis/frequentist_stats/sample_size.py
+++ b/src/mozanalysis/frequentist_stats/sample_size.py
@@ -151,7 +151,7 @@ class EmpericalEffectSizeResultsHolder(ResultsHolder):
             .format("{:.2%}", subset="rel_effect_size")
         )
 
-    def get_dataframe(self, style: bool = None) -> Union[pd.DataFrame, Styler]:
+    def get_dataframe(self, style: bool = True) -> Union[pd.DataFrame, Styler]:
         """returns dataframe for results from empirical_effect_size_sample_size_calc
 
         Arguments:

--- a/src/mozanalysis/frequentist_stats/sample_size.py
+++ b/src/mozanalysis/frequentist_stats/sample_size.py
@@ -26,7 +26,7 @@ from mozanalysis.utils import get_time_intervals
 class SampleSizeResultsHolder(UserDict):
     """
     Object to hold results from different methods.  It extends
-    the dictionary objects so that users can interact with it 
+    the dictionary objects so that users can interact with it
     with a dictionary with the same keys/values as before, making
     it backward compatible.  The dictionary functionality is extended to include
     additional attributes to hold metadata, a method for plotting results and

--- a/src/mozanalysis/frequentist_stats/sample_size.py
+++ b/src/mozanalysis/frequentist_stats/sample_size.py
@@ -354,10 +354,12 @@ def sample_size_curves(
         **solver_kwargs (dict): Arguments necessary for the provided solver.
 
     Returns:
-        A dictionary of pd.DataFrame objects. An item in the dictionary is
+        SampleSizeCurveResultHolder: The data attribute contains a dictionary
+        of pd.DataFrame objects. An item in the dictionary is
         created for each metric in metric_list, containing a DataFrame of sample
         size per branch, number of clients that satisfied targeting, and population
         proportion per branch at each value of the iterable parameter.
+        Additional methods for ease of use are documented in the class.
     """
     params = {"effect_size": effect_size, "power": power, "alpha": alpha}
     sim_var = [k for k, v in params.items() if type(v) in [list, np.ndarray, pd.Series]]
@@ -415,9 +417,11 @@ def difference_of_proportions_sample_size_calc(
             each columns.
 
     Returns:
-        A dictionary. Keys in the dictionary are the metrics column names from
+        SampleSizeResultsHolder: The data attribute contains a dictionary.
+        Keys in the dictionary are the metrics column names from
         the DataFrame; values are the required sample size per branch to achieve
-        the desired power for that metric.
+        the desired power for that metric. Additional methods for ease of use
+        are documented in the class.
     """
 
     def _get_sample_size_col(col):
@@ -478,9 +482,11 @@ def z_or_t_ind_sample_size_calc(
             each columns.
 
     Returns:
-        A dictionary. Keys in the dictionary are the metrics column names from
+        SampleSizeResultsHolder: The data attribute contains a dictionary.
+        Keys in the dictionary are the metrics column names from
         the DataFrame; values are the required sample size per branch to achieve
-        the desired power for that metric.
+        the desired power for that metric. Additional methods for ease of use
+        are documented in the class.
     """
     tests = {
         "normal": zt_ind_solve_power,
@@ -561,10 +567,12 @@ def empirical_effect_size_sample_size_calc(
             distribution of effect sizes observed in historical data.
 
     Returns:
-        A dictionary. Keys in the dictionary are the metrics column names from
+        EmpericalEffectSizeResultsHolder: The data attribute contains a dictionary.
+        Keys in the dictionary are the metrics column names from
         the DataFrame; values are dictionaries containing the required sample size
         per branch to achieve the desired power for that metric, along with
-        additional information.
+        additional information. Additional methods for ease of use
+        are documented in the class.
     """
 
     def _mann_whitney_solve_sample_size_approximation(
@@ -690,9 +698,11 @@ def poisson_diff_solve_sample_size(
             each columns.
 
     Returns:
-        A dictionary. Keys in the dictionary are the metrics column names from
+        SampleSizeResultsHolder: The data attribute contains a dictionary.
+        Keys in the dictionary are the metrics column names from
         the DataFrame; values are the required sample size per branch to achieve
-        the desired power for that metric.
+        the desired power for that metric.  Additional methods for ease of use
+        are documented in the class
     """
 
     def _get_sample_size_col(col):

--- a/src/mozanalysis/frequentist_stats/sample_size.py
+++ b/src/mozanalysis/frequentist_stats/sample_size.py
@@ -3,17 +3,17 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """module for sample size calculations"""
 
-from datetime import datetime
 from collections import UserDict
+from datetime import datetime
 from math import pi
 
-from scipy.stats import norm
-from statsmodels.stats.power import tt_ind_solve_power, zt_ind_solve_power
-from statsmodels.stats.proportion import samplesize_proportions_2indep_onetail
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from pandas.io.formats.style import Styler
-import matplotlib.pyplot as plt
+from scipy.stats import norm
+from statsmodels.stats.power import tt_ind_solve_power, zt_ind_solve_power
+from statsmodels.stats.proportion import samplesize_proportions_2indep_onetail
 
 from mozanalysis.bq import BigQueryContext
 from mozanalysis.experiment import TimeSeriesResult
@@ -31,7 +31,9 @@ class ResultsHolder(UserDict):
     it backward compatible.
     """
 
-    def __init__(self, *args, metrics: dict = None, params: dict = None, **kwargs):
+    def __init__(
+        self, *args, metrics: dict | None = None, params: dict | None = None, **kwargs
+    ):
         """
         Args:
             metrics (list, optional): List of metrics used to generate the results.
@@ -255,9 +257,9 @@ class SampleSizeCurveResultHolder(ResultsHolder):
         self,
         input_data: pd.DataFrame = None,
         show_population_pct: bool = True,
-        simulated_values: List[float] = None,
+        simulated_values: list[float] | None = None,
         append_stats: bool = False,
-        highlight_lessthan: List[float] = None,
+        highlight_lessthan: list[float] | None = None,
         trim_highlight_threshold: float = 0.15,
     ) -> Styler:
         """
@@ -347,7 +349,9 @@ class SampleSizeCurveResultHolder(ResultsHolder):
             # Only 3 cutoffs suported. Any others are silently dropped
             highlight_lessthan = sorted(highlight_lessthan)[:3]
             # Apply from highest to lowest cutoff so that lower cutoffs overwrite higher
-            for lim, colour in list(zip(highlight_lessthan, highlight_colours))[::-1]:
+            for lim, colour in list(
+                zip(highlight_lessthan, highlight_colours, strict=False)
+            )[::-1]:
                 disp = disp.highlight_between(
                     subset=simulated_values,
                     right=lim,
@@ -365,11 +369,7 @@ def sample_size_curves(
     power: float | np.ndarray | pd.Series | list[float] = 0.80,
     alpha: float | np.ndarray | pd.Series | list[float] = 0.05,
     **solver_kwargs,
-<<<<<<< HEAD
 ) -> SampleSizeCurveResultHolder:
-=======
-) -> dict[str, pd.DataFrame]:
->>>>>>> main
     """
     Loop over a list of different parameters to produce sample size estimates given
     those parameters. A single parameter in [effect_size, power, alpha] should

--- a/src/mozanalysis/frequentist_stats/sample_size.py
+++ b/src/mozanalysis/frequentist_stats/sample_size.py
@@ -214,8 +214,9 @@ class SampleSizeCurveResultHolder(ResultsHolder):
         """
         super().__init__(*args, **kwargs)
         # need to modify results so it matches the old format
+        sim_var = self._params["sim_var"]
         self.raw_df = pd.concat(
-            [el.set_index("effect_size", append=True) for el in self.data.values()]
+            [el.set_index(sim_var, append=True) for el in self.data.values()]
         )
         metrics = [el.name for el in self._metrics]
         results_dict = {}

--- a/src/mozanalysis/frequentist_stats/sample_size.py
+++ b/src/mozanalysis/frequentist_stats/sample_size.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """module for sample size calculations"""
 
-from typing import List, Union, Dict, Optional, Hashable, Iterator
+from typing import List, Union, Dict, Optional
 from datetime import datetime
 from collections import UserDict
 from math import pi
@@ -47,7 +47,7 @@ class ResultsHolder(UserDict):
         # this dict is what was returned from the sample size
         # methods historically
         self.data = {k: v for k, v in self.data.items()
-                        if k not in ['metrics', 'params']}
+                     if k not in ['metrics', 'params']}
 
     @staticmethod
     def make_friendly_name(ugly_name: str) -> str:

--- a/src/mozanalysis/frequentist_stats/sample_size.py
+++ b/src/mozanalysis/frequentist_stats/sample_size.py
@@ -118,9 +118,28 @@ class SampleSizeResultsHolder(ResultsHolder):
 
 
 class EmpericalEffectSizeResultsHolder(ResultsHolder):
+    "ResultsHolder for empirical_effect_size_sample_size_calc"
+
     def get_dataframe(
         self, tsdata: TimeSeriesResult = None, bq_context: BigQueryContext = None
     ) -> pd.DataFrame:
+        """returns dataframe for results from empirical_effect_size_sample_size_calc
+        the input timeseries data and a bigquery context can additionally be passed to
+        add a column  with the weekly mean of the metrics and the effect size relative
+        to that mean
+
+        Args:
+            tsdata (TimeSeriesResult, optional): input data used to generate the
+                    metrics. Defaults to None.
+            bq_context (BigQueryContext, optional): context for doing the weekly mean.
+                    Defaults to None.
+
+        Raises:
+            ValueError: raise an error if one of tsdata or bq_context is non-null
+
+        Returns:
+            pd.DataFrame: dataframe containing results
+        """
 
         formatted_results = {}
         for m, r in self.data.items():

--- a/src/mozanalysis/frequentist_stats/sample_size.py
+++ b/src/mozanalysis/frequentist_stats/sample_size.py
@@ -53,12 +53,12 @@ class ResultsHolder(UserDict):
 
     @property
     def metrics(self):
-        """the metrics property"""
+        """List of metrics used to generate the results. Defaults to None"""
         return self._metrics
 
     @property
     def params(self):
-        """the self property"""
+        """Parameters used to generated the results.  Defaults to None"""
         return self._params
 
     @staticmethod
@@ -208,11 +208,7 @@ class EmpiricalEffectSizeResultsHolder(ResultsHolder):
 
 class SampleSizeCurveResultHolder(ResultsHolder):
     def __init__(self, *args, **kwargs):
-        """
-        Args:
-            metrics (dict, optional): _description_. Defaults to None.
-            params (dict, optional): _description_. Defaults to None.
-        """
+        # uses the __init__ method for ResultsHolder
         super().__init__(*args, **kwargs)
         # need to modify results so it matches the old format
         sim_var = self._params["sim_var"]
@@ -311,9 +307,6 @@ class SampleSizeCurveResultHolder(ResultsHolder):
                 raise ValueError("append_stats is true but no raw data was provided")
             self.set_raw_data_stats(input_data)
             pretty_df = pd.concat([pretty_df, self._raw_data_stats], axis="columns")
-
-        if simulated_values is None:
-            simulated_values = self._params["simulated_values"]
 
         disp = (
             pretty_df.style.format(

--- a/src/mozanalysis/frequentist_stats/sample_size.py
+++ b/src/mozanalysis/frequentist_stats/sample_size.py
@@ -117,7 +117,7 @@ class SampleSizeResultsHolder(ResultsHolder):
         plt.show(block=False)
 
 
-class EmpericalEffectSizeResultsHolder(ResultsHolder):
+class EmpiricalEffectSizeResultsHolder(ResultsHolder):
     "ResultsHolder for empirical_effect_size_sample_size_calc"
 
     def style_empirical_sizing_result(
@@ -606,7 +606,7 @@ def empirical_effect_size_sample_size_calc(
     alpha: float = 0.05,
     parent_distribution: str = "normal",
     plot_effect_sizes: bool = False,
-) -> EmpericalEffectSizeResultsHolder:
+) -> EmpiricalEffectSizeResultsHolder:
     """
     Perform sample size calculation with empirical effect size and
     asymptotic approximation of Wilcoxen-Mann-Whitney U Test. Empirical effect size
@@ -639,7 +639,7 @@ def empirical_effect_size_sample_size_calc(
             distribution of effect sizes observed in historical data.
 
     Returns:
-        EmpericalEffectSizeResultsHolder: The data attribute contains a dictionary.
+        EmpiricalEffectSizeResultsHolder: The data attribute contains a dictionary.
         Keys in the dictionary are the metrics column names from
         the DataFrame; values are dictionaries containing the required sample size
         per branch to achieve the desired power for that metric, along with
@@ -737,7 +737,7 @@ def empirical_effect_size_sample_size_calc(
         "parent_distribution": parent_distribution,
     }
 
-    return EmpericalEffectSizeResultsHolder(
+    return EmpiricalEffectSizeResultsHolder(
         size_dict, metrics=metric_list, params=params
     )
 

--- a/src/mozanalysis/frequentist_stats/sample_size.py
+++ b/src/mozanalysis/frequentist_stats/sample_size.py
@@ -261,8 +261,8 @@ class SampleSizeCurveResultHolder(ResultsHolder):
         Args:
             input_data (pd.DataFrame, optional): Input data used to generate results,
                 used to generate statistics. Defaults to None.
-            show_population_pct (bool, optional): If true, percentage of population will be used in
-                output rather than raw counts. Defaults to True.
+            show_population_pct (bool, optional): If true, percentage of population
+                will be used in output rather than raw counts. Defaults to True.
             simulated_values (list, optional): List of simulated values to subset
                 output to. If None, all values will be included. Defaults to None.
             append_stats (bool, optional): _description_. If True, summary statistics on
@@ -365,7 +365,8 @@ class SampleSizeCurveResultHolder(ResultsHolder):
                 disp.set_properties(
                     subset=self._raw_data_stats.columns,
                     **{"background-color": "tan", "color": "black"},
-                ).format("{:.2%}", subset=["trim_change_mean", "trim_change_std"])
+                )
+                .format("{:.2%}", subset=["trim_change_mean", "trim_change_std"])
                 # highlight large changes in mean because of trimming
                 .applymap(
                     lambda x: (

--- a/src/mozanalysis/frequentist_stats/sample_size.py
+++ b/src/mozanalysis/frequentist_stats/sample_size.py
@@ -329,7 +329,7 @@ def sample_size_curves(
     power: Union[float, Union[np.ndarray, pd.Series, List[float]]] = 0.80,
     alpha: Union[float, Union[np.ndarray, pd.Series, List[float]]] = 0.05,
     **solver_kwargs,
-) -> Dict[str, pd.DataFrame]:
+) -> SampleSizeCurveResultHolder:
     """
     Loop over a list of different parameters to produce sample size estimates given
     those parameters. A single parameter in [effect_size, power, alpha] should
@@ -394,7 +394,7 @@ def difference_of_proportions_sample_size_calc(
     alpha: float = 0.05,
     power: float = 0.90,
     outlier_percentile: float = 99.5,
-) -> dict:
+) -> SampleSizeResultsHolder:
     """
     Perform sample size calculation for an experiment to test for a
     difference in proportions.
@@ -457,7 +457,7 @@ def z_or_t_ind_sample_size_calc(
     alpha: float = 0.05,
     power: float = 0.90,
     outlier_percentile: float = 99.5,
-) -> dict:
+) -> SampleSizeResultsHolder:
     """
     Perform sample size calculation for an experiment based on independent
     samples t or z tests.
@@ -528,7 +528,7 @@ def empirical_effect_size_sample_size_calc(
     alpha: float = 0.05,
     parent_distribution: str = "normal",
     plot_effect_sizes: bool = False,
-) -> dict:
+) -> EmpericalEffectSizeResultsHolder:
     """
     Perform sample size calculation with empirical effect size and
     asymptotic approximation of Wilcoxen-Mann-Whitney U Test. Empirical effect size
@@ -669,7 +669,7 @@ def poisson_diff_solve_sample_size(
     alpha: float = 0.05,
     power: float = 0.90,
     outlier_percentile: float = 99.5,
-) -> dict:
+) -> SampleSizeResultsHolder:
     """
     Sample size for test of difference of Poisson rates,
     based on Poisson rate's asymptotic normality.

--- a/src/mozanalysis/frequentist_stats/sample_size.py
+++ b/src/mozanalysis/frequentist_stats/sample_size.py
@@ -96,7 +96,7 @@ class SampleSizeResultsHolder(UserDict):
         df[result_name].plot(kind='bar')
         plt.ylabel(nice_result)
         plt.xlabel("Metric")
-        plt.show()
+        plt.show(block=False)
 
     def __getitem__(self, key: Hashable) -> object:
         """

--- a/src/mozanalysis/frequentist_stats/sample_size.py
+++ b/src/mozanalysis/frequentist_stats/sample_size.py
@@ -22,6 +22,7 @@ from mozanalysis.segments import Segment
 from mozanalysis.sizing import HistoricalTarget
 from mozanalysis.utils import get_time_intervals
 
+
 class SampleSizeResultsHolder(UserDict):
     """
     Object to hold results from different methods.  It extends
@@ -32,9 +33,9 @@ class SampleSizeResultsHolder(UserDict):
     a method for returning results as a dataframe
     """
     def __init__(self, *args,
-               metrics: dict=None,
-               params: dict=None,
-               **kwargs):
+                 metrics: dict = None,
+                 params: dict = None,
+                 **kwargs):
         """
         Args:
             metrics (dict, optional): _description_. Defaults to None.
@@ -46,15 +47,15 @@ class SampleSizeResultsHolder(UserDict):
         # create this attribute to hold only the results data
         # this dict is what was returned from the sample size
         # methods historically
-        self.results = {k:v for k,v in self.data.items() if k not in ['metrics', 'params']}
+        self.results = {k: v for k, v in self.data.items()
+                        if k not in ['metrics', 'params']}
 
     def get_dataframe(self) -> pd.DataFrame:
         """
         returns data as a dataframe rather than a dict
-        
 
         Returns:
-            (pd.DataFrame): dataframe of results 
+            (pd.DataFrame): dataframe of results
             The index is the metric and the columns are the outputs from
             the sample size method
         """
@@ -63,9 +64,8 @@ class SampleSizeResultsHolder(UserDict):
     @staticmethod
     def make_friendly_name(ugly_name: str) -> str:
         """Turns a name into a friendly name
-        by replacing underscores with spaces and 
-        capitlizing words other than ones like "per", "of", etc        
-
+        by replacing underscores with spaces and
+        capitlizing words other than ones like "per", "of", etc
         Args:
             ugly_name (str): name to make pretty
 
@@ -79,23 +79,26 @@ class SampleSizeResultsHolder(UserDict):
         pretty_name = " ".join(split_name)
         return pretty_name
 
-    def plot_results(self, result_name: str="sample_size_per_branch"):
+    def plot_results(self, result_name: str = "sample_size_per_branch"):
         """ plots the outputs of the sampling methods
 
         Args:
-            result_name (str): sample size method output to plot. Defaults to sample_size_per_branch
+            result_name (str): sample size method output to plot.
+            Defaults to sample_size_per_branch
         """
-        nice_metric_names = {el.name:(el.friendly_name if hasattr(el, 'friendly_name')
-                                      else self.make_friendly_name(el.name))
-                                      for el in self._metrics}
+        nice_metric_names = [el.friendly_name if hasattr(el, 'friendly_name')
+                             else self.make_friendly_name(el.name)
+                             for el in self._metrics]
+        nice_metric_map = {el.name: friendly_name for el, friendly_name
+                           in zip(self._metrics, nice_metric_names)}
         nice_result = self.make_friendly_name(result_name)
-        df = self.get_dataframe().rename(index=nice_metric_names)
+        df = self.get_dataframe().rename(index=nice_metric_map)
         df[result_name].plot(kind='bar')
         plt.ylabel(nice_result)
         plt.xlabel("Metric")
         plt.show()
 
-    def __getitem__(self, key: Hashable)-> object:
+    def __getitem__(self, key: Hashable) -> object:
         """
         overwrite the __getitem__ method that enables grabbing items with []
         so that only the keys associated with the results data are available
@@ -108,7 +111,7 @@ class SampleSizeResultsHolder(UserDict):
         """
         return self.results[key]
 
-    def __iter__(self)->Iterator:
+    def __iter__(self) -> Iterator:
         """
         overwrite this dict method so that iterating through the dict with .keys(),
         .values() and .items() will only return data associated with the results
@@ -118,7 +121,7 @@ class SampleSizeResultsHolder(UserDict):
         """
         return iter(self.results)
 
-    def __len__(self)->int:
+    def __len__(self) -> int:
         """
         overwrite dict method so the len() function returns length of key/value
         pairs associated with results
@@ -127,6 +130,7 @@ class SampleSizeResultsHolder(UserDict):
             int: length of results dict
         """
         return len(self.results)
+
 
 def sample_size_curves(
     df: pd.DataFrame,
@@ -249,12 +253,12 @@ def difference_of_proportions_sample_size_calc(
             "number_of_clients_targeted": len(df),
         }
     params = {'effect_size': effect_size,
-              'alpha':alpha,
-              'power':power,
-              'outlier_percentile':outlier_percentile}
+              'alpha': alpha,
+              'power': power,
+              'outlier_percentile': outlier_percentile}
 
-    return SampleSizeResultsHolder(results, metrics = metrics_list,
-                                   params = params)
+    return SampleSizeResultsHolder(results, metrics=metrics_list,
+                                   params=params)
 
 
 def z_or_t_ind_sample_size_calc(
@@ -316,14 +320,14 @@ def z_or_t_ind_sample_size_calc(
             "number_of_clients_targeted": len(df),
         }
     params = {'effect_size': effect_size,
-              'alpha':alpha,
-              'power':power,
-              'outlier_percentile':outlier_percentile,
-              'solver':solver,
-              'test':test}
+              'alpha': alpha,
+              'power': power,
+              'outlier_percentile': outlier_percentile,
+              'solver': solver,
+              'test': test}
 
-    return SampleSizeResultsHolder(results, metrics = metrics_list,
-                                   params = params)
+    return SampleSizeResultsHolder(results, metrics=metrics_list,
+                                   params=params)
 
 
 def empirical_effect_size_sample_size_calc(
@@ -517,12 +521,12 @@ def poisson_diff_solve_sample_size(
             "number_of_clients_targeted": len(df),
         }
     params = {'effect_size': effect_size,
-            'alpha':alpha,
-            'power':power,
-            'outlier_percentile':outlier_percentile}
-   
-    return SampleSizeResultsHolder(results, metrics = metrics_list,
-                                   params = params)
+              'alpha': alpha,
+              'power': power,
+              'outlier_percentile': outlier_percentile}
+
+    return SampleSizeResultsHolder(results, metrics=metrics_list,
+                                   params=params)
 
 
 def variable_enrollment_length_sample_size_calc(

--- a/tests/frequentist_stats/test_sample_size_calc.py
+++ b/tests/frequentist_stats/test_sample_size_calc.py
@@ -100,3 +100,4 @@ def test_results_holder():
 
     # make sure the  get_dataframe isn't broken
     _ = res.get_dataframe()
+    res.plot_results()

--- a/tests/frequentist_stats/test_sample_size_calc.py
+++ b/tests/frequentist_stats/test_sample_size_calc.py
@@ -9,6 +9,7 @@ import pytest
 from mozanalysis.frequentist_stats.sample_size import (
     empirical_effect_size_sample_size_calc,
     sample_size_curves,
+    z_or_t_ind_sample_size_calc,
 )
 from mozanalysis.metrics.desktop import search_clients_daily, uri_count
 
@@ -125,7 +126,7 @@ def test_curve_results_holder():
         alpha=0.05,
         outlier_percentile=99.5,
     )
-    metric_names = set([el.name for el in metrics])
+    metric_names = {el.name for el in metrics}
 
     # set should only have 2 values: "search_clients_daily" "uri_count"
     assert len(res) == len(metric_names)
@@ -242,7 +243,9 @@ def test_get_styled_dataframe():
         highlight_lessthan=[(10, "green"), (20, "blue")],
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="append_stats is true but no raw data was provided"
+    ):
         _ = res.get_styled_dataframe(append_stats=True)
 
     # check that subset works
@@ -277,7 +280,7 @@ def test_results_holder():
 
     metrics = [search_clients_daily, uri_count]
     res = z_or_t_ind_sample_size_calc(df, metrics)
-    metric_names = set([el.name for el in metrics])
+    metric_names = {el.name for el in metrics}
 
     # set should only have 2 values: "search_clients_daily" "uri_count"
     assert len(res) == len(metric_names)

--- a/tests/frequentist_stats/test_sample_size_calc.py
+++ b/tests/frequentist_stats/test_sample_size_calc.py
@@ -93,19 +93,20 @@ def test_emperical_effect_size_results_holder(fake_ts_result):
 
     result_df = result.get_dataframe()
     expected_columns = {
+        "relative_effect_size",
         "effect_size_value",
+        "mean_value",
         "std_dev_value",
         "sample_size_per_branch",
         "population_percent_per_branch",
+        "effect_size_period",
+        "mean_period",
+        "std_dev_period",
     }
     assert set(result_df.columns) == expected_columns
 
-    # test exception gets raised when one of bq_context or tsdata is null
-    with pytest.raises(ValueError):
-        _ = result.get_dataframe(bq_context="I am a bq_context ;)")
-
-    with pytest.raises(ValueError):
-        _ = result.get_dataframe(tsdata=fake_ts_result)
+    # check that style runs successfully
+    _ = result.get_dataframe(style=True)
 
 
 def test_curve_results_holder():
@@ -149,8 +150,8 @@ def test_curve_results_holder():
     assert set(iter_keys) == metric_names
 
 
-def test_curve_results_holder_pretty_df():
-    """this test ensures the pretty_results function works as expected"""
+def test_curve_results_holder_get_dataframe():
+    """this test ensures the get_dataframe function works as expected"""
     df = pd.DataFrame(
         {
             search_clients_daily.name: np.random.normal(size=100),
@@ -183,35 +184,39 @@ def test_curve_results_holder_pretty_df():
     cols_with_stats = cols_no_stats | stats_cols
 
     with pytest.raises(ValueError):
-        _ = res.pretty_results(append_stats=True)
+        _ = res.get_dataframe(append_stats=True)
 
-    no_stats = res.pretty_results()
-    assert set(no_stats.data.columns) == cols_no_stats
+    no_stats = res.get_dataframe()
+    assert set(no_stats.columns) == cols_no_stats
 
-    also_no_stats = res.pretty_results(input_data=df, append_stats=False)
-    assert set(also_no_stats.data.columns) == cols_no_stats
+    also_no_stats = res.get_dataframe(input_data=df, append_stats=False)
+    assert set(also_no_stats.columns) == cols_no_stats
 
-    with_stats = res.pretty_results(input_data=df, append_stats=True)
-    assert set(with_stats.data.columns) == cols_with_stats
+    with_stats = res.get_dataframe(input_data=df, append_stats=True)
+    assert set(with_stats.columns) == cols_with_stats
 
     # make sure highlight_listthan won't throw an error
-    _ = res.pretty_results(
+    _ = res.get_dataframe(
         input_data=df,
         append_stats=True,
         highlight_lessthan=[(10, "green"), (20, "blue")],
+        style=True,
     )
 
     # check that subset works
     subset_experiment_effect_sizes = experiment_effect_sizes[1:-1]
     subset_cols_with_stats = set(subset_experiment_effect_sizes) | stats_cols
 
-    no_stats = res.pretty_results(simulated_values=subset_experiment_effect_sizes)
+    no_stats = res.get_dataframe(
+        simulated_values=subset_experiment_effect_sizes, style=True
+    )
     assert set(no_stats.data.columns) == set(subset_experiment_effect_sizes)
 
-    with_stats = res.pretty_results(
+    with_stats = res.get_dataframe(
         input_data=df,
         append_stats=True,
         simulated_values=subset_experiment_effect_sizes,
+        style=True,
     )
     assert set(with_stats.data.columns) == subset_cols_with_stats
 

--- a/tests/frequentist_stats/test_sample_size_calc.py
+++ b/tests/frequentist_stats/test_sample_size_calc.py
@@ -77,7 +77,7 @@ def test_empirical_effect_size_sample_size_calc(fake_ts_result):
         )
 
 
-def test_emperical_effect_size_results_holder(fake_ts_result):
+def test_empirical_effect_size_results_holder(fake_ts_result):
     """checks the get_dataframe method doesn't throw an error and has
     the expected columns in the case where a weekly mean is not generated"""
 

--- a/tests/frequentist_stats/test_sample_size_calc.py
+++ b/tests/frequentist_stats/test_sample_size_calc.py
@@ -77,6 +77,30 @@ def test_empirical_effect_size_sample_size_calc(fake_ts_result):
         )
 
 
+def test_emperical_effect_size_results_holder(fake_ts_result):
+    """checks the get_dataframe method doesn't throw an error and has
+    the expected columns in the case where a weekly mean is not generated"""
+
+    @dataclass
+    class FakeMetric:
+        name: str
+
+    metric_list = [FakeMetric(name="metric1"), FakeMetric(name="metric2")]
+
+    result = empirical_effect_size_sample_size_calc(
+        res=fake_ts_result, bq_context=None, metric_list=metric_list
+    )
+
+    result_df = result.get_dataframe()
+    expected_columns = {
+        "effect_size_value",
+        "std_dev_value",
+        "sample_size_per_branch",
+        "population_percent_per_branch",
+    }
+    assert set(result_df.columns) == expected_columns
+
+
 def test_curve_results_holder():
     """this test ensures the results_holder object has properly formatted attributes
     and is backward compatible"""

--- a/tests/frequentist_stats/test_sample_size_calc.py
+++ b/tests/frequentist_stats/test_sample_size_calc.py
@@ -78,7 +78,7 @@ def test_empirical_effect_size_sample_size_calc(fake_ts_result):
 
 
 def test_curve_results_holder():
-    """ this test ensures the results_holder object has properly formatted attributes
+    """this test ensures the results_holder object has properly formatted attributes
     and is backward compatible"""
     df = pd.DataFrame(
         {
@@ -119,7 +119,7 @@ def test_curve_results_holder():
 
 
 def test_curve_results_holder_pretty_df():
-    """ this test ensures the pretty_results function works as expected"""
+    """this test ensures the pretty_results function works as expected"""
     df = pd.DataFrame(
         {
             search_clients_daily.name: np.random.normal(size=100),
@@ -139,14 +139,16 @@ def test_curve_results_holder_pretty_df():
         outlier_percentile=99.5,
     )
 
-    experiment_effect_sizes = res._params['simulated_values']
+    experiment_effect_sizes = res._params["simulated_values"]
     cols_no_stats = set(list(experiment_effect_sizes))
-    stats_cols = {'mean',
-                  'std',
-                  'mean_trimmed',
-                  'std_trimmed',
-                  'trim_change_mean',
-                  'trim_change_std'}
+    stats_cols = {
+        "mean",
+        "std",
+        "mean_trimmed",
+        "std_trimmed",
+        "trim_change_mean",
+        "trim_change_std",
+    }
     cols_with_stats = cols_no_stats | stats_cols
 
     with pytest.raises(ValueError):
@@ -162,9 +164,11 @@ def test_curve_results_holder_pretty_df():
     assert set(with_stats.data.columns) == cols_with_stats
 
     # make sure highlight_listthan won't throw an error
-    _ = res.pretty_results(input_data=df,
-                           append_stats=True,
-                           highlight_lessthan=[(10, "green"), (20, "blue")])
+    _ = res.pretty_results(
+        input_data=df,
+        append_stats=True,
+        highlight_lessthan=[(10, "green"), (20, "blue")],
+    )
 
     # check that subset works
     subset_experiment_effect_sizes = experiment_effect_sizes[1:-1]
@@ -173,9 +177,11 @@ def test_curve_results_holder_pretty_df():
     no_stats = res.pretty_results(simulated_values=subset_experiment_effect_sizes)
     assert set(no_stats.data.columns) == set(subset_experiment_effect_sizes)
 
-    with_stats = res.pretty_results(input_data=df,
-                                    append_stats=True,
-                                    simulated_values=subset_experiment_effect_sizes)
+    with_stats = res.pretty_results(
+        input_data=df,
+        append_stats=True,
+        simulated_values=subset_experiment_effect_sizes,
+    )
     assert set(with_stats.data.columns) == subset_cols_with_stats
 
 

--- a/tests/frequentist_stats/test_sample_size_calc.py
+++ b/tests/frequentist_stats/test_sample_size_calc.py
@@ -74,3 +74,29 @@ def test_empirical_effect_size_sample_size_calc(fake_ts_result):
         np.testing.assert_allclose(
             r["population_percent_per_branch"], 0.844, atol=0.001
         )
+
+
+def test_results_holder():
+    df = pd.DataFrame(
+        {
+            search_clients_daily.name: np.random.normal(size=100),
+            uri_count.name: np.random.normal(size=100),
+        }
+    )
+
+    metrics = [search_clients_daily, uri_count]
+    res = z_or_t_ind_sample_size_calc(df, metrics)
+    metric_names = set([el.name for el in metrics])
+
+    # set should only have 2 values: "search_clients_daily" "uri_count"
+    assert len(res) == len(metric_names)
+    assert set(res.keys()) == metric_names
+    assert len(res.values()) == len(metric_names)
+    iter_keys = []
+    for key, _ in res.items():
+        iter_keys.append(key)
+    assert len(iter_keys) == len(metric_names)
+    assert set(iter_keys) == metric_names
+
+    # make sure the  get_dataframe isn't broken
+    _ = res.get_dataframe()

--- a/tests/frequentist_stats/test_sample_size_calc.py
+++ b/tests/frequentist_stats/test_sample_size_calc.py
@@ -181,6 +181,37 @@ def test_curve_results_holder_dataframe():
     assert set(no_stats.columns) == cols_no_stats
 
 
+def test_curve_results_holder_dataframe_simvar_alpha():
+    """this test ensures the dataframe property function works as expected"""
+    df = pd.DataFrame(
+        {
+            search_clients_daily.name: np.random.normal(size=100),
+            uri_count.name: np.random.normal(size=100),
+        }
+    )
+
+    metrics = [search_clients_daily, uri_count]
+    alpha = np.arange(0.01, 0.11, 0.01)
+    res = sample_size_curves(
+        df,
+        metrics,
+        solver=z_or_t_ind_sample_size_calc,
+        effect_size=0.05,
+        power=0.8,
+        alpha=alpha,
+        outlier_percentile=99.5,
+    )
+
+    cols_no_stats = {
+        "sample_size_per_branch",
+        "population_percent_per_branch",
+        "number_of_clients_targeted",
+    }
+
+    no_stats = res.dataframe
+    assert set(no_stats.columns) == cols_no_stats
+
+
 def test_get_styled_dataframe():
     "make sure highlight_listthan will not throw an error"
     df = pd.DataFrame(

--- a/tests/frequentist_stats/test_sample_size_calc.py
+++ b/tests/frequentist_stats/test_sample_size_calc.py
@@ -100,6 +100,13 @@ def test_emperical_effect_size_results_holder(fake_ts_result):
     }
     assert set(result_df.columns) == expected_columns
 
+    # test exception gets raised when one of bq_context or tsdata is null
+    with pytest.raises(ValueError):
+        _ = result.get_dataframe(bq_context="I am a bq_context ;)")
+
+    with pytest.raises(ValueError):
+        _ = result.get_dataframe(tsdata=fake_ts_result)
+
 
 def test_curve_results_holder():
     """this test ensures the results_holder object has properly formatted attributes


### PR DESCRIPTION
This PR is adding wrapper classes for results returned from the objects in sample_size_calc.py.  The idea is to add functionality to make it easier to work with results while maintaining backward compatibility

Fixes #204 