### PR TITLE
feat: add __version__ attribute

### DIFF
--- a/src/mozanalysis/__init__.py
+++ b/src/mozanalysis/__init__.py
@@ -7,6 +7,12 @@
 # We use it to expose modules available in mozanalysis package.
 # https://github.com/mozilla/jetstream
 import os
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("mozanalysis")
+except PackageNotFoundError:
+    __version__ = "unknown version"
 
 __all__ = []
 basedir = os.path.dirname(__file__)


### PR DESCRIPTION
This is meant to address this issue: https://github.com/mozilla/mozanalysis/issues/11

One can access the version using the __version__ attribute:

```
>>> import mozanalysis
>>> mozanalysis.__version__
'2023.11.4.dev12+g230bf07.d20240227'
```

It looks like the version is generated by `setuptools_scm`, and it gets grabbed by `importlib.metadata`.  We could add a little logic just to grab the date part of it so it matches with the git tags.