### PR TITLE
add storage API to speed up data loading

### DIFF
--- a/src/mozanalysis/bq.py
+++ b/src/mozanalysis/bq.py
@@ -6,6 +6,8 @@ import re
 
 from google.api_core.exceptions import Conflict
 from google.cloud import bigquery
+from google.cloud.bigquery_storage import BigQueryReadClient
+
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +40,7 @@ class BigQueryContext:
         self.dataset_id = dataset_id
         self.project_id = project_id
         self.client = bigquery.Client(project=project_id)
+        self.read_client = BigQueryReadClient()
 
     def run_query(self, sql, results_table=None, replace_tables=False):
         """Run a query and return the result.

--- a/src/mozanalysis/sizing.py
+++ b/src/mozanalysis/sizing.py
@@ -225,7 +225,7 @@ class HistoricalTarget:
 
         return bq_context.run_query(
             self._metrics_sql, full_res_table_name, replace_tables
-        ).to_dataframe()
+        ).to_dataframe(bqstorage_client=bq_context.read_client)
 
     def get_time_series_data(
         self,
@@ -353,7 +353,6 @@ class HistoricalTarget:
         target_list: Optional[Segment] = None,
         custom_targets_query: Optional[str] = None,
     ) -> str:
-
         return """
         {targets_query}
         """.format(
@@ -449,7 +448,6 @@ class HistoricalTarget:
     def _build_targets_query(
         self, target_list: List[Segment], time_limits: TimeLimits
     ) -> str:
-
         target_queries = []
         target_columns = []
         dates_columns = []
@@ -464,18 +462,14 @@ class HistoricalTarget:
                 """
         ds_{i} AS (
                 {query}
-            ),""".format(
-                    i=i, query=query_for_target
-                )
+            ),""".format(i=i, query=query_for_target)
             )
 
             target_columns.append(
                 """
                     ,ds_{i}.{name}
                     ,ds_{i}.target_first_date as {name}_first_date
-                """.format(
-                    i=i, name=t.name
-                )
+                """.format(i=i, name=t.name)
             )
 
             if i != 0:
@@ -485,9 +479,7 @@ class HistoricalTarget:
                         ON ds_{i}.client_id = ds_0.client_id
                         AND ds_{i}.target_first_date <= ds_0.target_last_date
                         AND ds_{i}.target_last_date >= ds_0.target_first_date
-                        """.format(
-                        i=i
-                    )
+                        """.format(i=i)
                 )
 
             dates_columns.append("{name}_first_date".format(name=t.name))
@@ -512,9 +504,7 @@ class HistoricalTarget:
                 SELECT * FROM joined
                 UNPIVOT(min_dates for target_date in ({target_first_dates}))
             )
-        """.format(
-            target_first_dates=", ".join(c for c in dates_columns)
-        )
+        """.format(target_first_dates=", ".join(c for c in dates_columns))
 
         return """
         {query_for_targets}
@@ -554,9 +544,7 @@ class HistoricalTarget:
                 """    LEFT JOIN (
         {query}
         ) ds_{i} USING (client_id, analysis_window_start, analysis_window_end)
-                """.format(
-                    query=query_for_metrics, i=i
-                )
+                """.format(query=query_for_metrics, i=i)
             )
 
             for m in ds_metrics[ds]:


### PR DESCRIPTION
Fixes #77 

I had a hard time figuring out how to best use the API and given the age of the story it might be out of date.  I ran an experiment where I locally ran the following code on this branch and on main:

```
test_target = HistoricalTarget(
    experiment_name='test_targ', # A name for the analysis, which is only used in the table names when saving results in BigQuery
    start_date='2022-01-01', # First date for the dummy enrollment period of the analysis
    num_dates_enrollment=28, # Number of days used to check for clients that satisfy conditions in Segments
    analysis_length=7, # Number of days used to calculate metrics for each client in the study
)

df = test_target.get_single_window_data(
    bq_context=bq_context,
    metric_list=[active_hours, uri_count, search_count],
    target_list=[weekday_regular_us]
)
```

I used the jupyter `%%timeit` magic to measure how fast.  On main it ran in `37.4 s ± 8.17 s per loop (mean ± std. dev. of 7 runs, 1 loop each)` while on the feature branch it ran in `31.3 s ± 1.4 s per loop (mean ± std. dev. of 7 runs, 1 loop each)`.  Not very scientific, especially given the std deviation on the main, but it looks like the improvement is fairly minor in this case.