### PR TITLE
Verify target_list and metric_list sources match

### DIFF
--- a/src/mozanalysis/config.py
+++ b/src/mozanalysis/config.py
@@ -64,6 +64,7 @@ class _ConfigLoader:
                 metric_definition.data_source.name, app_name
             ),
             bigger_is_better=metric_definition.bigger_is_better,
+            app_name=app_name,
         )
 
     def get_data_source(self, data_source_slug: str, app_name: str):
@@ -92,6 +93,7 @@ class _ConfigLoader:
                 else data_source_definition.experiments_column_type
             ),
             default_dataset=data_source_definition.default_dataset,
+            app_name=app_name,
         )
 
     def get_segment(self, segment_slug: str, app_name: str):
@@ -115,6 +117,7 @@ class _ConfigLoader:
             .render(),
             friendly_name=segment_definition.friendly_name,
             description=segment_definition.description,
+            app_name=app_name,
         )
 
     def get_segment_data_source(self, data_source_slug: str, app_name: str):
@@ -140,6 +143,7 @@ class _ConfigLoader:
             client_id_column=data_source_definition.client_id_column,
             submission_date_column=data_source_definition.submission_date_column,
             default_dataset=data_source_definition.default_dataset,
+            app_name=app_name,
         )
 
     def get_outcome_metric(self, metric_slug: str, outcome_slug: str, app_name: str):

--- a/src/mozanalysis/metrics/__init__.py
+++ b/src/mozanalysis/metrics/__init__.py
@@ -77,6 +77,8 @@ class DataSource:
             `{dataset}` in from_expr if a value is not provided
             at runtime. Mandatory if from_expr contains a
             `{dataset}` parameter.
+        app_name: (str, optional): app_name used with metric-hub,
+            used for validation
     """
 
     name = attr.ib(validator=attr.validators.instance_of(str))
@@ -85,6 +87,7 @@ class DataSource:
     client_id_column = attr.ib(default="client_id", type=str)
     submission_date_column = attr.ib(default="submission_date", type=str)
     default_dataset = attr.ib(default=None, type=str | None)
+    app_name = attr.ib(default=None, type=str | None)
 
     EXPERIMENT_COLUMN_TYPES = (None, "simple", "native", "glean")
 
@@ -353,6 +356,8 @@ class Metric:
         friendly_name (str): A human-readable dashboard title for this metric
         description (str): A paragraph of Markdown-formatted text describing
             what the metric measures, to be shown on dashboards
+        app_name: (str, optional): app_name used with metric-hub,
+            used for validation
     """
 
     name = attr.ib(type=str)
@@ -361,6 +366,7 @@ class Metric:
     friendly_name = attr.ib(type=str | None, default=None)
     description = attr.ib(type=str | None, default=None)
     bigger_is_better = attr.ib(type=bool, default=True)
+    app_name = attr.ib(type=str | None, default=None)
 
 
 def agg_sum(select_expr: str) -> str:

--- a/src/mozanalysis/segments/__init__.py
+++ b/src/mozanalysis/segments/__init__.py
@@ -58,6 +58,8 @@ class SegmentDataSource:
             `{dataset}` in from_expr if a value is not provided
             at runtime. Mandatory if from_expr contains a
             `{dataset}` parameter.
+        app_name: (str, optional): app_name used with metric-hub,
+            used for validation
     """
 
     name = attr.ib(validator=attr.validators.instance_of(str))
@@ -67,6 +69,7 @@ class SegmentDataSource:
     client_id_column = attr.ib(default="client_id", type=str)
     submission_date_column = attr.ib(default="submission_date", type=str)
     default_dataset = attr.ib(default=None, type=str | None)
+    app_name = attr.ib(default=None, type=str | None)
 
     @default_dataset.validator
     def _check_default_dataset_provided_if_needed(self, attribute, value):
@@ -188,6 +191,8 @@ class Segment:
         friendly_name (str): A human-readable dashboard title for this segment
         description (str): A paragraph of Markdown-formatted text describing
             the segment in more detail, to be shown on dashboards
+        app_name: (str, optional): app_name used with metric-hub,
+            used for validation
     """
 
     name = attr.ib(type=str)
@@ -195,3 +200,4 @@ class Segment:
     select_expr = attr.ib(type=str)
     friendly_name = attr.ib(type=str | None, default=None)
     description = attr.ib(type=str | None, default=None)
+    app_name = attr.ib(type=str | None, default=None)

--- a/src/mozanalysis/sizing.py
+++ b/src/mozanalysis/sizing.py
@@ -3,9 +3,9 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
+import warnings
 from datetime import date
 from typing import TYPE_CHECKING
-import warnings
 
 import attr
 

--- a/src/mozanalysis/sizing.py
+++ b/src/mozanalysis/sizing.py
@@ -170,14 +170,10 @@ class HistoricalTarget:
         target_list_sources = {el.app_name for el in target_list if el.app_name}
 
         if len(metric_list_sources) > 1:
-            warnings.warn(
-                "metric_list contains multiple metric-hub sources", stacklevel=1
-            )
+            warnings.warn("metric_list contains multiple metric-hub apps", stacklevel=1)
 
         if len(target_list_sources) > 1:
-            warnings.warn(
-                "target_list contains multiple metric-hub sources", stacklevel=1
-            )
+            warnings.warn("target_list contains multiple metric-hub apps", stacklevel=1)
 
         if (
             metric_list_sources
@@ -185,7 +181,7 @@ class HistoricalTarget:
             and metric_list_sources != target_list_sources
         ):
             warnings.warn(
-                "metric_list and target_list metric-hub sources do not match",
+                "metric_list and target_list metric-hub apps do not match",
                 stacklevel=1,
             )
 
@@ -262,7 +258,7 @@ class HistoricalTarget:
                 warnings.warn(
                     (
                         f"Metric {metric_obj.name} is all 0, which may indicate"
-                        + " segments and metric do not have a common source"
+                        + " segments and metric do not have a common app"
                     ),
                     stacklevel=1,
                 )
@@ -542,9 +538,7 @@ class HistoricalTarget:
                 SELECT * FROM joined
                 UNPIVOT(min_dates for target_date in ({target_first_dates}))
             )
-        """.format(
-            target_first_dates=", ".join(c for c in dates_columns)
-        )
+        """.format(target_first_dates=", ".join(c for c in dates_columns))
 
         return f"""
         {target_def}

--- a/src/mozanalysis/sizing.py
+++ b/src/mozanalysis/sizing.py
@@ -262,7 +262,7 @@ class HistoricalTarget:
                 warnings.warn(
                     (
                         f"Metric {metric_obj.name} is all 0, which may indicate"
-                        + " segements and metric do not have a common source"
+                        + " segments and metric do not have a common source"
                     ),
                     stacklevel=1,
                 )
@@ -542,7 +542,9 @@ class HistoricalTarget:
                 SELECT * FROM joined
                 UNPIVOT(min_dates for target_date in ({target_first_dates}))
             )
-        """.format(target_first_dates=", ".join(c for c in dates_columns))
+        """.format(
+            target_first_dates=", ".join(c for c in dates_columns)
+        )
 
         return f"""
         {target_def}

--- a/src/mozanalysis/sizing.py
+++ b/src/mozanalysis/sizing.py
@@ -170,18 +170,23 @@ class HistoricalTarget:
         target_list_sources = {el.app_name for el in target_list if el.app_name}
 
         if len(metric_list_sources) > 1:
-            raise ValueError("metric_list contains multiple metric-hub sources")
+            warnings.warn(
+                "metric_list contains multiple metric-hub sources", stacklevel=1
+            )
 
         if len(target_list_sources) > 1:
-            raise ValueError("target_list contains multiple metric-hub sources")
+            warnings.warn(
+                "target_list contains multiple metric-hub sources", stacklevel=1
+            )
 
         if (
             metric_list_sources
             and target_list_sources
             and metric_list_sources != target_list_sources
         ):
-            raise ValueError(
-                "metric_list and target_list metric-hub sources do not match"
+            warnings.warn(
+                "metric_list and target_list metric-hub sources do not match",
+                stacklevel=1,
             )
 
         last_date_full_data = add_days(
@@ -252,20 +257,15 @@ class HistoricalTarget:
             self._metrics_sql, full_res_table_name, replace_tables
         ).to_dataframe()
 
-        if (len(metric_list_sources) < len(metric_list)) or (
-            len(target_list_sources) < len(target_list)
-        ):
-            # case where there is a custom definition
-            # so sources have not been checked
-            for metric_obj in metric_list:
-                if all(output[metric_obj.name] == 0):
-                    raise warnings.warn(
-                        (
-                            f"Metric {metric_obj.name} is all 0, which may indicate"
-                            + " segements and metric do not have a common source"
-                        ),
-                        stacklevel=1,
-                    )
+        for metric_obj in metric_list:
+            if all(output[metric_obj.name] == 0):
+                warnings.warn(
+                    (
+                        f"Metric {metric_obj.name} is all 0, which may indicate"
+                        + " segements and metric do not have a common source"
+                    ),
+                    stacklevel=1,
+                )
         return output
 
     def get_time_series_data(

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -1,7 +1,6 @@
-import pandas as pd
-
 import mozanalysis.metrics.desktop as mad
 import mozanalysis.segments.desktop as msd
+import pandas as pd
 import pytest
 from cheap_lint import sql_lint
 from mozanalysis.config import ConfigLoader

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -52,7 +52,7 @@ def test_mixed_metric():
         "allweek_regular_v1", "firefox_desktop"
     )
 
-    with pytest.warns(match="metric_list contains multiple metric-hub sources"):
+    with pytest.warns(match="metric_list contains multiple metric-hub apps"):
         _ = ht.get_single_window_data(
             bq_context,
             metric_list=[active_hours, baseline_ping_count],
@@ -78,9 +78,7 @@ def test_target_metric_mismatch():
         "allweek_regular_v1", "firefox_desktop"
     )
 
-    with pytest.warns(
-        match="metric_list and target_list metric-hub sources do not match"
-    ):
+    with pytest.warns(match="metric_list and target_list metric-hub apps do not match"):
         _ = ht.get_single_window_data(
             bq_context,
             metric_list=[baseline_ping_count],
@@ -119,9 +117,7 @@ def test_target_metric_mismatch_with_custom():
         "allweek_regular_v1", "firefox_desktop"
     )
 
-    with pytest.warns(
-        match="metric_list and target_list metric-hub sources do not match"
-    ):
+    with pytest.warns(match="metric_list and target_list metric-hub apps do not match"):
         _ = ht.get_single_window_data(
             bq_context,
             metric_list=[baseline_ping_count, qcdou],

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -1,13 +1,12 @@
-import pytest
-
 import mozanalysis.metrics.desktop as mad
 import mozanalysis.segments.desktop as msd
+import pytest
 from cheap_lint import sql_lint
+from mozanalysis.config import ConfigLoader
 from mozanalysis.experiment import TimeLimits
 from mozanalysis.metrics import DataSource, Metric
 from mozanalysis.segments import Segment, SegmentDataSource
 from mozanalysis.sizing import HistoricalTarget
-from mozanalysis.config import ConfigLoader
 
 
 def test_mixed_metric():


### PR DESCRIPTION
Fixes #173 

- Add `app_name` attribute to Metric, Segement, etc classes so that sources from metric-hub can be checked
- exceptions raised for metric_list with multiple sources, target_list with multiple sources and when the sources between the two don't match
- Add warning for causes where there are metrics or segements not from metric-hub, and a metric has all 0s (which would indicate no support for the metric and therefore a mismatch between target and metric sources)