### PR TITLE
add analysis unit to exposure signal; consistent id usage in query builders

### DIFF
--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -487,7 +487,7 @@ class Experiment:
 
         if exposure_signal:
             exposure_query = custom_exposure_query or exposure_signal.build_query(
-                time_limits
+                time_limits, self.analysis_unit
             )
         else:
             exposure_query = custom_exposure_query or self._build_exposure_query(
@@ -561,7 +561,7 @@ class Experiment:
         if exposure_signal and analysis_basis != AnalysisBasis.ENROLLMENTS:
             exposure_query = f"""
             SELECT * FROM (
-                {exposure_signal.build_query(time_limits)}
+                {exposure_signal.build_query(time_limits, self.analysis_unit)}
             )
             WHERE num_exposure_events > 0
             """
@@ -1459,7 +1459,9 @@ class TimeSeriesResult:
             full_table_name=self.fully_qualified_table_name,
         )
 
-    def _table_sample_size_query(self, client_id_column: str = "client_id") -> str:
+    def _table_sample_size_query(
+        self, client_id_column: str = AnalysisUnit.CLIENT.value
+    ) -> str:
         return f"""
         SELECT
             COUNT(*) as population_size

--- a/src/mozanalysis/exposure.py
+++ b/src/mozanalysis/exposure.py
@@ -3,6 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import attr
+from metric_config_parser import AnalysisUnit
+from typing_extensions import assert_never
 
 from mozanalysis.metrics import DataSource
 
@@ -44,6 +46,7 @@ class ExposureSignal:
     def build_query(
         self,
         time_limits,
+        analysis_unit: AnalysisUnit = AnalysisUnit.CLIENT,
     ):
         """Return a nearly self-contained query for determining exposures.
 
@@ -51,15 +54,21 @@ class ExposureSignal:
         be executed to query all exposures based on the exposure metric
         from this data source.
         """
+        if analysis_unit == AnalysisUnit.CLIENT:
+            ds_id = self.data_source.client_id_column
+        elif analysis_unit == AnalysisUnit.PROFILE_GROUP:
+            ds_id = self.data_source.group_id_column
+        else:
+            assert_never(analysis_unit)
         return """SELECT
-            e.client_id,
+            e.{analysis_id},
             e.branch,
             MIN(ds.submission_date) AS exposure_date,
             COUNT(ds.submission_date) AS num_exposure_events
         FROM raw_enrollments e
             LEFT JOIN (
                 SELECT
-                    {client_id} AS client_id,
+                    {ds_id} AS {analysis_id},
                     {submission_date} AS submission_date
                 FROM {from_expr}
                 WHERE {submission_date}
@@ -67,12 +76,12 @@ class ExposureSignal:
                     AND DATE_ADD('{date_end}', INTERVAL {window_end} DAY)
                     AND {exposure_signal}
             ) AS ds
-            ON ds.client_id = e.client_id AND
+            ON ds.{analysis_id} = e.{analysis_id} AND
                 ds.submission_date >= e.enrollment_date
         GROUP BY
-            e.client_id,
+            e.{analysis_id},
             e.branch""".format(
-            client_id=self.data_source.client_id_column,
+            ds_id=ds_id,
             submission_date=self.data_source.submission_date_column,
             from_expr=self.data_source.from_expr_for(None),
             date_start=time_limits.first_enrollment_date,
@@ -82,4 +91,5 @@ class ExposureSignal:
             window_start=self.window_start or 0,
             window_end=self.window_end or 0,
             exposure_signal=self.select_expr,
+            analysis_id=analysis_unit.value,
         )

--- a/src/mozanalysis/metrics.py
+++ b/src/mozanalysis/metrics.py
@@ -203,7 +203,7 @@ class DataSource:
             assert_never(analysis_unit)
 
         return """SELECT
-            e.{id_column},
+            e.{analysis_id},
             e.branch,
             e.analysis_window_start,
             e.analysis_window_end,
@@ -212,14 +212,14 @@ class DataSource:
             {metrics}
         FROM enrollments e
             LEFT JOIN {from_expr} ds
-                ON ds.{ds_id} = e.{id_column}
+                ON ds.{ds_id} = e.{analysis_id}
                 AND ds.{submission_date} BETWEEN '{fddr}' AND '{lddr}'
                 AND ds.{submission_date} BETWEEN
                     DATE_ADD(e.{date}, interval e.analysis_window_start day)
                     AND DATE_ADD(e.{date}, interval e.analysis_window_end day)
                 {ignore_pre_enroll_first_day}
         GROUP BY
-            e.{id_column},
+            e.{analysis_id},
             e.branch,
             e.num_exposure_events,
             e.exposure_date,
@@ -243,7 +243,7 @@ class DataSource:
                 submission_date=self.submission_date_column,
                 experiment_slug=experiment_slug,
             ),
-            id_column=analysis_unit.value,
+            analysis_id=analysis_unit.value,
         )
 
     def build_query_targets(
@@ -413,7 +413,7 @@ class Metric:
         data_source (DataSource): where to find the metric
         select_expr (str): a SQL snippet representing a clause of a SELECT
             expression describing how to compute the metric; must include an
-            aggregation function since it will be GROUPed BY client_id
+            aggregation function since it will be GROUPed BY the analysis unit
             and branch
         friendly_name (str): A human-readable dashboard title for this metric
         description (str): A paragraph of Markdown-formatted text describing

--- a/src/mozanalysis/segments.py
+++ b/src/mozanalysis/segments.py
@@ -43,6 +43,9 @@ class SegmentDataSource:
             `{dataset}` parameter.
         app_name: (str, optional): app_name used with metric-hub,
             used for validation
+        group_id_column (str, optional): Name of the column that
+            contains the ``group_id`` (join key). Defaults to
+            'profile_group_id'.
     """
 
     name = attr.ib(validator=attr.validators.instance_of(str))
@@ -98,7 +101,7 @@ class SegmentDataSource:
         else:
             assert_never(analysis_unit)
         return """SELECT
-            e.{ds_id},
+            e.{analysis_id},
             e.branch,
             {segments}
         FROM raw_enrollments e
@@ -110,7 +113,7 @@ class SegmentDataSource:
                 AND ds.{submission_date} BETWEEN
                     DATE_ADD(e.enrollment_date, interval {window_start} day)
                     AND DATE_ADD(e.enrollment_date, interval {window_end} day)
-        GROUP BY e.{ds_id}, e.branch""".format(
+        GROUP BY e.{analysis_id}, e.branch""".format(
             ds_id=ds_id,
             submission_date=self.submission_date_column or "submission_date",
             from_expr=self.from_expr_for(from_expr_dataset),


### PR DESCRIPTION
- exposure signal build_query updates needed to support profile_group_id
- re-checked the prior changes and made some updates for consistency (e.g., `analysis_id` instead of `id_column` in metrics.py)
  - also looked like the segments query was slightly wrong
- some minor comment updates to reflect the generic usage of analysis unit vs specifically client_id