### PR TITLE
use analysis_id instead of client/profile_group for consistency

### DIFF
--- a/src/mozanalysis/exposure.py
+++ b/src/mozanalysis/exposure.py
@@ -61,14 +61,14 @@ class ExposureSignal:
         else:
             assert_never(analysis_unit)
         return """SELECT
-            e.{analysis_id},
+            e.analysis_id,
             e.branch,
             MIN(ds.submission_date) AS exposure_date,
             COUNT(ds.submission_date) AS num_exposure_events
         FROM raw_enrollments e
             LEFT JOIN (
                 SELECT
-                    {ds_id} AS {analysis_id},
+                    {ds_id} AS analysis_id,
                     {submission_date} AS submission_date
                 FROM {from_expr}
                 WHERE {submission_date}
@@ -76,10 +76,10 @@ class ExposureSignal:
                     AND DATE_ADD('{date_end}', INTERVAL {window_end} DAY)
                     AND {exposure_signal}
             ) AS ds
-            ON ds.{analysis_id} = e.{analysis_id} AND
+            ON ds.analysis_id = e.analysis_id AND
                 ds.submission_date >= e.enrollment_date
         GROUP BY
-            e.{analysis_id},
+            e.analysis_id,
             e.branch""".format(
             ds_id=ds_id,
             submission_date=self.data_source.submission_date_column,
@@ -91,5 +91,4 @@ class ExposureSignal:
             window_start=self.window_start or 0,
             window_end=self.window_end or 0,
             exposure_signal=self.select_expr,
-            analysis_id=analysis_unit.value,
         )

--- a/src/mozanalysis/metrics.py
+++ b/src/mozanalysis/metrics.py
@@ -203,7 +203,7 @@ class DataSource:
             assert_never(analysis_unit)
 
         return """SELECT
-            e.{analysis_id},
+            e.analysis_id,
             e.branch,
             e.analysis_window_start,
             e.analysis_window_end,
@@ -212,14 +212,14 @@ class DataSource:
             {metrics}
         FROM enrollments e
             LEFT JOIN {from_expr} ds
-                ON ds.{ds_id} = e.{analysis_id}
+                ON ds.{ds_id} = e.analysis_id
                 AND ds.{submission_date} BETWEEN '{fddr}' AND '{lddr}'
                 AND ds.{submission_date} BETWEEN
                     DATE_ADD(e.{date}, interval e.analysis_window_start day)
                     AND DATE_ADD(e.{date}, interval e.analysis_window_end day)
                 {ignore_pre_enroll_first_day}
         GROUP BY
-            e.{analysis_id},
+            e.analysis_id,
             e.branch,
             e.num_exposure_events,
             e.exposure_date,
@@ -243,7 +243,6 @@ class DataSource:
                 submission_date=self.submission_date_column,
                 experiment_slug=experiment_slug,
             ),
-            analysis_id=analysis_unit.value,
         )
 
     def build_query_targets(

--- a/src/mozanalysis/segments.py
+++ b/src/mozanalysis/segments.py
@@ -101,19 +101,19 @@ class SegmentDataSource:
         else:
             assert_never(analysis_unit)
         return """SELECT
-            e.{analysis_id},
+            e.analysis_id,
             e.branch,
             {segments}
         FROM raw_enrollments e
             LEFT JOIN {from_expr} ds
-                ON ds.{ds_id} = e.{analysis_id}
+                ON ds.{ds_id} = e.analysis_id
                 AND ds.{submission_date} BETWEEN
                     DATE_ADD('{first_enrollment}', interval {window_start} day)
                     AND DATE_ADD('{last_enrollment}', interval {window_end} day)
                 AND ds.{submission_date} BETWEEN
                     DATE_ADD(e.enrollment_date, interval {window_start} day)
                     AND DATE_ADD(e.enrollment_date, interval {window_end} day)
-        GROUP BY e.{analysis_id}, e.branch""".format(
+        GROUP BY e.analysis_id, e.branch""".format(
             ds_id=ds_id,
             submission_date=self.submission_date_column or "submission_date",
             from_expr=self.from_expr_for(from_expr_dataset),
@@ -124,7 +124,6 @@ class SegmentDataSource:
             segments=",\n            ".join(
                 f"{m.select_expr} AS {m.name}" for m in segment_list
             ),
-            analysis_id=analysis_unit.value,
         )
 
     def build_query_target(

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -34,7 +34,7 @@ def test_datasource_build_query_analysis_units(analysis_unit):
     lddr = tl.last_date_data_required
 
     expected_query = f"""SELECT
-            e.{analysis_unit.value},
+            e.analysis_id,
             e.branch,
             e.analysis_window_start,
             e.analysis_window_end,
@@ -43,14 +43,14 @@ def test_datasource_build_query_analysis_units(analysis_unit):
             {empty_str}
         FROM enrollments e
             LEFT JOIN my_table.name ds
-                ON ds.{analysis_unit.value} = e.{analysis_unit.value}
+                ON ds.{analysis_unit.value} = e.analysis_id
                 AND ds.submission_date BETWEEN '{fddr}' AND '{lddr}'
                 AND ds.submission_date BETWEEN
                     DATE_ADD(e.enrollment_date, interval e.analysis_window_start day)
                     AND DATE_ADD(e.enrollment_date, interval e.analysis_window_end day)
                 {empty_str}
         GROUP BY
-            e.{analysis_unit.value},
+            e.analysis_id,
             e.branch,
             e.num_exposure_events,
             e.exposure_date,


### PR DESCRIPTION
Before this change, the analysis tables would have an inconsistent identifier column called either `client_id` or `profile_group_id`, depending on the experiment. This change renames that column to `analysis_id` for all experiments.