### PR TITLE
add warning if wrong analysis_unit in custom query

### DIFF
--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -447,6 +447,7 @@ class Experiment:
         exposure_signal: ExposureSignal | None = None,
         segment_list=None,
         sample_size: int = 100,
+        suppress_custom_query_validation: bool = False,
     ) -> str:
         """Return a SQL query for querying enrollment and exposure data.
 
@@ -505,11 +506,19 @@ class Experiment:
                 if self.analysis_unit == AnalysisUnit.PROFILE_GROUP
                 else AnalysisUnit.PROFILE_GROUP.value
             )
-            logger.warning(
-                f"custom_enrollments_query contains {wrong_value}, but experiment uses"
-                + f"{self.analysis_unit.value}. This could indicate a problem with the"
-                + "custom enrollments query."
-            )
+
+            if not suppress_custom_query_validation:
+                raise ValueError(
+                    f"custom_enrollments_query contains {wrong_value}, but experiment "
+                    + f"uses {self.analysis_unit.value}. This could indicate a problem "
+                    + "with the custom enrollments query."
+                )
+            else:
+                logger.warning(
+                    f"custom_enrollments_query contains {wrong_value}, but experiment "
+                    + f"uses {self.analysis_unit.value}. This could indicate a problem "
+                    + "with the custom enrollments query."
+                )
 
         if custom_exposure_query and (
             (
@@ -526,11 +535,18 @@ class Experiment:
                 if self.analysis_unit == AnalysisUnit.PROFILE_GROUP
                 else AnalysisUnit.PROFILE_GROUP.value
             )
-            logger.warning(
-                f"custom_exposure_query contains {wrong_value}, but experiment uses"
-                + f"{self.analysis_unit.value}. This could indicate a problem with the"
-                + "custom exposure query."
-            )
+            if not suppress_custom_query_validation:
+                raise ValueError(
+                    f"custom_exposure_query contains {wrong_value}, but experiment "
+                    + f"uses {self.analysis_unit.value}. This could indicate a problem "
+                    + "with the custom exposure query."
+                )
+            else:
+                logger.warning(
+                    f"custom_exposure_query contains {wrong_value}, but experiment "
+                    + f"uses {self.analysis_unit.value}. This could indicate a problem "
+                    + "with the custom exposure query."
+                )
 
         enrollments_query = custom_enrollments_query or self._build_enrollments_query(
             time_limits,

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -879,6 +879,142 @@ def test_resolve_missing_column_names():
 @pytest.mark.parametrize(
     "analysis_unit", [AnalysisUnit.CLIENT, AnalysisUnit.PROFILE_GROUP]
 )
+def test_enrollments_query_with_valid_custom_enrollments(caplog, analysis_unit):
+    exp = Experiment("slug", "2019-01-01", 8, analysis_unit=analysis_unit)
+
+    tl = TimeLimits.for_ts(
+        first_enrollment_date="2019-01-01",
+        last_date_full_data="2019-03-01",
+        time_series_period="weekly",
+        num_dates_enrollment=8,
+    )
+
+    wrong_analysis_unit = (
+        AnalysisUnit.CLIENT.value
+        if analysis_unit == AnalysisUnit.PROFILE_GROUP
+        else AnalysisUnit.PROFILE_GROUP.value
+    )
+
+    exp.build_enrollments_query(
+        time_limits=tl,
+        enrollments_query_type=EnrollmentsQueryType.NORMANDY,
+        custom_enrollments_query=f"SELECT {analysis_unit.value} AS analysis_id",
+    )
+
+    warning_log = (
+        f"custom_enrollments_query contains {wrong_analysis_unit}, but experiment uses"
+        + f"{analysis_unit.value}. This could indicate a problem with the"
+        + "custom enrollments query."
+    )
+
+    assert warning_log.strip() not in caplog.text.strip()
+
+
+@pytest.mark.parametrize(
+    "analysis_unit", [AnalysisUnit.CLIENT, AnalysisUnit.PROFILE_GROUP]
+)
+def test_enrollments_query_with_valid_custom_exposure(caplog, analysis_unit):
+    exp = Experiment("slug", "2019-01-01", 8, analysis_unit=analysis_unit)
+
+    tl = TimeLimits.for_ts(
+        first_enrollment_date="2019-01-01",
+        last_date_full_data="2019-03-01",
+        time_series_period="weekly",
+        num_dates_enrollment=8,
+    )
+
+    wrong_analysis_unit = (
+        AnalysisUnit.CLIENT.value
+        if analysis_unit == AnalysisUnit.PROFILE_GROUP
+        else AnalysisUnit.PROFILE_GROUP.value
+    )
+
+    exp.build_enrollments_query(
+        time_limits=tl,
+        enrollments_query_type=EnrollmentsQueryType.NORMANDY,
+        custom_exposure_query=f"SELECT {analysis_unit.value} AS analysis_id",
+    )
+
+    warning_log = (
+        f"custom_exposure_query contains {wrong_analysis_unit}, but experiment uses"
+        + f"{analysis_unit.value}. This could indicate a problem with the"
+        + "custom exposure query."
+    )
+
+    assert warning_log.strip() not in caplog.text.strip()
+
+
+@pytest.mark.parametrize(
+    "analysis_unit", [AnalysisUnit.CLIENT, AnalysisUnit.PROFILE_GROUP]
+)
+def test_enrollments_query_with_invalid_custom_enrollments(caplog, analysis_unit):
+    exp = Experiment("slug", "2019-01-01", 8, analysis_unit=analysis_unit)
+
+    tl = TimeLimits.for_ts(
+        first_enrollment_date="2019-01-01",
+        last_date_full_data="2019-03-01",
+        time_series_period="weekly",
+        num_dates_enrollment=8,
+    )
+
+    wrong_analysis_unit = (
+        AnalysisUnit.CLIENT.value
+        if analysis_unit == AnalysisUnit.PROFILE_GROUP
+        else AnalysisUnit.PROFILE_GROUP.value
+    )
+
+    exp.build_enrollments_query(
+        time_limits=tl,
+        enrollments_query_type=EnrollmentsQueryType.NORMANDY,
+        custom_enrollments_query=f"SELECT {wrong_analysis_unit} AS analysis_id",
+    )
+
+    warning_log = (
+        f"custom_enrollments_query contains {wrong_analysis_unit}, but experiment uses"
+        + f"{analysis_unit.value}. This could indicate a problem with the"
+        + "custom enrollments query."
+    )
+
+    assert warning_log in caplog.text
+
+
+@pytest.mark.parametrize(
+    "analysis_unit", [AnalysisUnit.CLIENT, AnalysisUnit.PROFILE_GROUP]
+)
+def test_enrollments_query_with_invalid_custom_exposure(caplog, analysis_unit):
+    exp = Experiment("slug", "2019-01-01", 8, analysis_unit=analysis_unit)
+
+    tl = TimeLimits.for_ts(
+        first_enrollment_date="2019-01-01",
+        last_date_full_data="2019-03-01",
+        time_series_period="weekly",
+        num_dates_enrollment=8,
+    )
+
+    wrong_analysis_unit = (
+        AnalysisUnit.CLIENT.value
+        if analysis_unit == AnalysisUnit.PROFILE_GROUP
+        else AnalysisUnit.PROFILE_GROUP.value
+    )
+
+    exp.build_enrollments_query(
+        time_limits=tl,
+        enrollments_query_type=EnrollmentsQueryType.NORMANDY,
+        custom_exposure_query=f"SELECT {wrong_analysis_unit} AS analysis_id",
+    )
+
+    warning_log = (
+        f"custom_exposure_query contains {wrong_analysis_unit}, but experiment uses"
+        + f"{analysis_unit.value}. This could indicate a problem with the"
+        + "custom exposure query."
+    )
+
+    assert warning_log.strip() in caplog.text.strip()
+
+
+@pytest.mark.parametrize(
+    "analysis_unit", [AnalysisUnit.CLIENT, AnalysisUnit.PROFILE_GROUP]
+)
 def test_enrollments_query_analysis_unit(analysis_unit):
     exp = Experiment("slug", "2019-01-01", 8, analysis_unit=analysis_unit)
 


### PR DESCRIPTION
Updated some more comments about custom queries to reflect the change in queries from client_id to analysis_id.