### PR TITLE
chore: update docs-deploy to supported dep versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
             git config user.email "fx-data-platform@mozilla.com"
             git config user.name "CircleCI docs-deploy job"
             npm install -g --silent gh-pages@^2.0.0
-            gh-pages --dotfiles --message "[skip ci] Updates" --dist docs/_build/html --no-push
+            gh-pages --dotfiles --message "[skip ci] Updates" --dist docs/_build/html
 
 ####################
 # Workflows: see https://circleci.com/docs/2.0/workflows/
@@ -122,9 +122,9 @@ workflows:
       - docs-deploy:
           requires:
             - docs
-          # filters:
-          #   branches:
-          #     only: main
+          filters:
+            branches:
+              only: main
   tagged-deploy:
     jobs:
       - deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
 
   docs-deploy:
     docker:
-      - image: node:22-slim
+      - image: node:22
     steps:
       - checkout
       - attach_workspace:
@@ -105,8 +105,8 @@ jobs:
           command: |
             git config user.email "fx-data-platform@mozilla.com"
             git config user.name "CircleCI docs-deploy job"
-            npm install -g --silent gh-pages@^6.0.0
-            gh-pages --dotfiles --message "[skip ci] Updates" --dist docs/_build/html
+            npm install -g --silent gh-pages@^2.0.0
+            gh-pages --dotfiles --message "[skip ci] Updates" --dist docs/_build/html --no-push
 
 ####################
 # Workflows: see https://circleci.com/docs/2.0/workflows/
@@ -122,9 +122,9 @@ workflows:
       - docs-deploy:
           requires:
             - docs
-          filters:
-            branches:
-              only: main
+          # filters:
+          #   branches:
+          #     only: main
   tagged-deploy:
     jobs:
       - deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
 
   docs-deploy:
     docker:
-      - image: node:8.10.0
+      - image: node:22-slim
     steps:
       - checkout
       - attach_workspace:
@@ -105,7 +105,7 @@ jobs:
           command: |
             git config user.email "fx-data-platform@mozilla.com"
             git config user.name "CircleCI docs-deploy job"
-            npm install -g --silent gh-pages@2.0.1
+            npm install -g --silent gh-pages@^6.0.0
             gh-pages --dotfiles --message "[skip ci] Updates" --dist docs/_build/html
 
 ####################


### PR DESCRIPTION
Updates node base image and gh-pages dep to latest because
- node version 8.10.0 is 7 years old
- gh-pages version 2.0.1 is 6 years old