### PR TITLE
chore: fix warnings raised by tests

### DIFF
--- a/src/mozanalysis/frequentist_stats/sample_size.py
+++ b/src/mozanalysis/frequentist_stats/sample_size.py
@@ -327,7 +327,7 @@ class SampleSizeCurveResultHolder(ResultsHolder):
                 )
                 .format("{:.2%}", subset=["trim_change_mean", "trim_change_std"])
                 # highlight large changes in mean because of trimming
-                .applymap(
+                .map(
                     lambda x: (
                         large_change_format_str if x > trim_highlight_threshold else ""
                     ),

--- a/tests/bayesian_stats/test_bayesian_bootstrap.py
+++ b/tests/bayesian_stats/test_bayesian_bootstrap.py
@@ -110,7 +110,9 @@ def test_bootstrap_one_branch_multistat():
 
 
 def test_compare_branches():
-    data = pd.DataFrame(index=range(60000), columns=["branch", "val"], dtype="float")
+    data = pd.DataFrame(index=range(60000), columns=["branch", "val"]).astype(
+        dtype={"branch": "string", "val": "float"}
+    )
     data.iloc[::3, 0] = "control"
     data.iloc[1::3, 0] = "same"
     data.iloc[2::3, 0] = "bigger"
@@ -145,7 +147,9 @@ def test_compare_branches():
 
 
 def test_compare_branches_multistat():
-    data = pd.DataFrame(index=range(60000), columns=["branch", "val"], dtype="float")
+    data = pd.DataFrame(index=range(60000), columns=["branch", "val"]).astype(
+        dtype={"branch": "string", "val": "float"}
+    )
     data.iloc[::3, 0] = "control"
     data.iloc[1::3, 0] = "same"
     data.iloc[2::3, 0] = "bigger"

--- a/tests/bayesian_stats/test_survival_func.py
+++ b/tests/bayesian_stats/test_survival_func.py
@@ -34,7 +34,9 @@ def test_get_thresholds_2():
 
 
 def test_one_thresh():
-    df = pd.DataFrame(columns=["branch", "val"], index=range(1000))
+    df = pd.DataFrame(columns=["branch", "val"], index=range(1000)).astype(
+        dtype={"branch": "string", "val": "float"}
+    )
     df.iloc[::2, 0] = "control"
     df.iloc[1::2, 0] = "test"
     df.fillna(0, inplace=True)
@@ -84,7 +86,9 @@ def test_one_thresh():
 
 
 def test_compare_branches():
-    df = pd.DataFrame(columns=["branch", "val"], index=range(1000), dtype="float")
+    df = pd.DataFrame(columns=["branch", "val"], index=range(1000)).astype(
+        dtype={"branch": "string", "val": "float"}
+    )
     df.iloc[::2, 0] = "control"
     df.iloc[1::2, 0] = "test"
     df.iloc[:300, 1] = range(300)
@@ -111,12 +115,14 @@ def test_compare_branches():
 
 
 def test_few_auto_thresholds():
-    df = pd.DataFrame(columns=["branch", "val"], index=range(1000))
+    df = pd.DataFrame(columns=["branch", "val"], index=range(1000)).astype(
+        dtype={"branch": "string", "val": "float"}
+    )
     df.iloc[::2, 0] = "control"
     df.iloc[1::2, 0] = "test"
     df.fillna(0, inplace=True)
-    df.iloc[20:30] = 1
-    df.iloc[405] = 100
+    df.iloc[20:30, 1] = 1
+    df.iloc[405, 1] = 100
 
     res = mabssf.compare_branches(df, "val")
     assert set(res["individual"]["test"].index) == {0, 1}

--- a/tests/frequentist_stats/test_bootstrap.py
+++ b/tests/frequentist_stats/test_bootstrap.py
@@ -107,10 +107,8 @@ def test_bootstrap_one_branch_multistat():
 
 
 def test_compare_branches():
-    data = pd.DataFrame(
-        index=range(60000),
-        columns=["branch", "val"],
-        dtype="float",
+    data = pd.DataFrame(index=range(60000), columns=["branch", "val"]).astype(
+        dtype={"branch": "string", "val": "float"}
     )
     data.iloc[::3, 0] = "control"
     data.iloc[1::3, 0] = "same"
@@ -146,10 +144,8 @@ def test_compare_branches():
 
 
 def test_compare_branches_multistat():
-    data = pd.DataFrame(
-        index=range(60000),
-        columns=["branch", "val"],
-        dtype="float",
+    data = pd.DataFrame(index=range(60000), columns=["branch", "val"]).astype(
+        dtype={"branch": "string", "val": "float"}
     )
     data.iloc[::3, 0] = "control"
     data.iloc[1::3, 0] = "same"

--- a/tests/frequentist_stats/test_linear_model_functions.py
+++ b/tests/frequentist_stats/test_linear_model_functions.py
@@ -692,9 +692,13 @@ def test_fit_model_covariate_fails_on_bad_data():
     model_df = test_model_covariate.model_df.copy()
     model_df.loc[:, test_model_covariate.target] = [0] * model_df.shape[0]
 
-    with pytest.raises(
-        FailedToFitModel,
-        match="Failed to fit model for target search_count using covariate search_count_pre",  # noqa: E501
+    with (
+        pytest.raises(
+            FailedToFitModel,
+            match="Failed to fit model for target search_count using "
+            "covariate search_count_pre",
+        ),
+        pytest.warns(RuntimeWarning, match="divide by zero encountered in log"),
     ):
         mafslm.fit_model(
             model_df,

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -52,12 +52,27 @@ def test_mixed_metric():
         "allweek_regular_v1", "firefox_desktop"
     )
 
-    with pytest.warns(match="metric_list contains multiple metric-hub apps"):
+    with pytest.warns(UserWarning) as warns:
         _ = ht.get_single_window_data(
             bq_context,
             metric_list=[active_hours, baseline_ping_count],
             target_list=[allweek_regular_v1],
         )
+
+    warning_messages = [str(m.message) for m in warns]
+    assert len(warns) == 4
+    assert "metric_list contains multiple metric-hub apps" in warning_messages
+    assert (
+        "metric_list and target_list metric-hub apps do not match" in warning_messages
+    )
+    assert (
+        "Metric active_hours is all 0, which may indicate segments and metric "
+        "do not have a common app" in warning_messages
+    )
+    assert (
+        "Metric baseline_ping_count is all 0, which may indicate segments "
+        "and metric do not have a common app" in warning_messages
+    )
 
 
 def test_target_metric_mismatch():
@@ -78,12 +93,22 @@ def test_target_metric_mismatch():
         "allweek_regular_v1", "firefox_desktop"
     )
 
-    with pytest.warns(match="metric_list and target_list metric-hub apps do not match"):
+    with pytest.warns(UserWarning) as warns:
         _ = ht.get_single_window_data(
             bq_context,
             metric_list=[baseline_ping_count],
             target_list=[allweek_regular_v1],
         )
+
+    warning_messages = [str(m.message) for m in warns]
+    assert len(warns) == 2
+    assert (
+        "metric_list and target_list metric-hub apps do not match" in warning_messages
+    )
+    assert (
+        "Metric baseline_ping_count is all 0, which may indicate segments and metric "
+        "do not have a common app" in warning_messages
+    )
 
 
 def test_target_metric_mismatch_with_custom():
@@ -117,12 +142,26 @@ def test_target_metric_mismatch_with_custom():
         "allweek_regular_v1", "firefox_desktop"
     )
 
-    with pytest.warns(match="metric_list and target_list metric-hub apps do not match"):
+    with pytest.warns(UserWarning) as warns:
         _ = ht.get_single_window_data(
             bq_context,
             metric_list=[baseline_ping_count, qcdou],
             target_list=[allweek_regular_v1],
         )
+
+    warning_messages = [str(m.message) for m in warns]
+    assert len(warns) == 3
+    assert (
+        "metric_list and target_list metric-hub apps do not match" in warning_messages
+    )
+    assert (
+        "Metric qcdou is all 0, which may indicate segments and metric "
+        "do not have a common app" in warning_messages
+    )
+    assert (
+        "Metric baseline_ping_count is all 0, which may indicate segments "
+        "and metric do not have a common app" in warning_messages
+    )
 
 
 def test_multiple_datasource():


### PR DESCRIPTION
Noticed there were a handful of warnings coming out of running pytest due to some deprecated calls, or in some cases expected behavior that we weren't accounting for in the tests (e.g., UserWarnings that we expect to raise, or side effects of our use of 0'd out dataframes for tests).