### PR TITLE
Add new experiments_column_type to support events_stream tables

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -7,7 +7,9 @@ from mozanalysis.experiment import TimeLimits
 from mozanalysis.metrics import AnalysisBasis, DataSource, Metric
 
 
-@pytest.mark.parametrize("experiments_column_type", [None, "simple", "native", "glean"])
+@pytest.mark.parametrize(
+    "experiments_column_type", [None, "simple", "native", "glean", "events_stream"]
+)
 def test_datasource_constructor_succeeds(experiments_column_type):
     DataSource(
         name="foo",


### PR DESCRIPTION
fixes https://github.com/mozilla/jetstream/issues/2174

I'm unclear if there's more plumbing this needs.

I went for a condition that's going to match the other type's semantics of checking both experiment and branch, but I don't understand enough to tell if that's actually necessary or preferrable.