### PR TITLE
fix: group_id_column carried over from mcp DS

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -107,9 +107,9 @@ mizani==0.13.1
 mock==5.2.0
     # via mozanalysis
     # via -r -
-mozilla-metric-config-parser==2024.11.1
+mozilla-metric-config-parser==2025.5.2
     # via mozanalysis
-mozilla-nimbus-schemas==2025.1.1
+mozilla-nimbus-schemas==3001.0.0
     # via mozilla-metric-config-parser
 numpy==1.26.4
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -843,12 +843,12 @@ mock==5.2.0 \
     --hash=sha256:4e460e818629b4b173f32d08bf30d3af8123afbb8e04bb5707a1fd4799e503f0 \
     --hash=sha256:7ba87f72ca0e915175596069dbbcc7c75af7b5e9b9bc107ad6349ede0819982f
     # via -r requirements.in
-mozilla-metric-config-parser==2024.11.1 \
-    --hash=sha256:4f972b669cdaefc1ff5e7372a93bbd23151d7bbdf8f3dbe2b4c3ff4ab61b33bb
+mozilla-metric-config-parser==2025.5.2 \
+    --hash=sha256:6af4e72ab8fe8c43e333d2787e3eb4b375fd7d34fcf6c98d5119751d5499f903
     # via -r requirements.in
-mozilla-nimbus-schemas==2025.1.1 \
-    --hash=sha256:05e3300a2d9dc507b96bac586b089dba551ab77c82053776148f41b8536802cf \
-    --hash=sha256:ed3de9cb913520d355a59e96e68783780a11c149edc0cd568178165245c68b46
+mozilla-nimbus-schemas==3001.0.0 \
+    --hash=sha256:25b89f8ce1e547b383e067023027b84bdbd01cc32b0375dcc5446df737ded533 \
+    --hash=sha256:dedd11aed9f793b47de319f3ce104ff07f77a8d896234547feb41a76dc7a57e1
     # via
     #   -r requirements.in
     #   mozilla-metric-config-parser

--- a/src/mozanalysis/segments.py
+++ b/src/mozanalysis/segments.py
@@ -46,6 +46,12 @@ class SegmentDataSource:
         group_id_column (str, optional): Name of the column that
             contains the ``group_id`` (join key). Defaults to
             'profile_group_id'.
+        glean_client_id_column (str, optional): Name of the column that
+            contains the *glean* telemetry ``client_id`` (join key).
+            This is also used to specify that the data source supports glean.
+        legacy_client_id_column (str, optional): Name of the column that
+            contains the *legacy* telemetry ``client_id`` (join key).
+            This is also used to specify that the data source supports legacy.
     """
 
     name = attr.ib(validator=attr.validators.instance_of(str))
@@ -57,6 +63,8 @@ class SegmentDataSource:
     default_dataset = attr.ib(default=None, type=str | None)
     app_name = attr.ib(default=None, type=str | None)
     group_id_column = attr.ib(default=AnalysisUnit.PROFILE_GROUP.value, type=str)
+    glean_client_id_column = attr.ib(default=None, type=str)
+    legacy_client_id_column = attr.ib(default=None, type=str)
 
     @default_dataset.validator
     def _check_default_dataset_provided_if_needed(self, attribute, value):


### PR DESCRIPTION
We added `group_id_column` here before it was supported in metric-config-parser, but never updated once mcp added support so the config is allowed but not actually used. This rectifies that situation and so it should be used after this change (and after jetstream updates to use it).