### PR TITLE
fix: sanity metric query strings should be f-strings

### DIFF
--- a/src/mozanalysis/metrics.py
+++ b/src/mozanalysis/metrics.py
@@ -380,7 +380,7 @@ class DataSource:
                     name=self.name + "_has_contradictory_branch",
                     data_source=self,
                     select_expr=agg_any(
-                        """`mozfun.map.get_key`(
+                        f"""`mozfun.map.get_key`(
                 ds.experiments, '{experiment_slug}'
             ) != e.branch"""
                     ),
@@ -402,7 +402,7 @@ class DataSource:
                     name=self.name + "_has_contradictory_branch",
                     data_source=self,
                     select_expr=agg_any(
-                        """`mozfun.map.get_key`(
+                        f"""`mozfun.map.get_key`(
                 ds.experiments, '{experiment_slug}'
             ).branch != e.branch"""
                     ),
@@ -424,7 +424,7 @@ class DataSource:
                     name=self.name + "_has_contradictory_branch",
                     data_source=self,
                     select_expr=agg_any(
-                        """`mozfun.map.get_key`(
+                        f"""`mozfun.map.get_key`(
                 ds.ping_info.experiments, '{experiment_slug}'
             ).branch != e.branch"""
                     ),
@@ -446,7 +446,7 @@ class DataSource:
                     name=self.name + "_has_contradictory_branch",
                     data_source=self,
                     select_expr=agg_any(
-                        """IF(
+                        f"""IF(
                 JSON_VALUE(ds.event_extra, '$.experiment') = '{experiment_slug}',
                 JSON_VALUE(ds.event_extra, '$.branch'),
                 NULL


### PR DESCRIPTION
I don't know if this is correct, but when I added `experiments_column_type == "events_stream"`, I saw that the first metric doesn't use f-string and the second metric does, even though both reference experiment_slug.