### PR TITLE
fix: regex for tag checking

### DIFF
--- a/.github/workflows/tagged-deploy.yml
+++ b/.github/workflows/tagged-deploy.yml
@@ -3,7 +3,7 @@ name: Tagged Deploy
 on:
   push:
     tags:
-      - '[0-9][0-9][0-9][0-9].[0-9]{1,2}.[0-9]+' # Calver: YYYY.M.MINOR
+      - '[0-9][0-9][0-9][0-9].[0-9][0-9]?.[0-9]+' # Calver: YYYY.M.MINOR
 
 jobs:
   deploy:


### PR DESCRIPTION
GH Actions has a limited set of [filter patterns](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet) so some regex things that we used in CircleCI don't work.