### PR TITLE
feat: compute sample_id dynamically for enrollments

### DIFF
--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -844,6 +844,7 @@ class Experiment:
         return f"""
         SELECT
             e.{self.analysis_unit.value} AS analysis_id,
+            udf.safe_sample_id({self.analysis_unit.value}) AS sample_id,
             `mozfun.map.get_key`(e.event_map_values, 'branch')
                 AS branch,
             MIN(e.submission_date) AS enrollment_date,
@@ -877,6 +878,7 @@ class Experiment:
         return """
         SELECT
             b.client_info.client_id AS analysis_id,
+            udf.safe_sample_id(b.client_info.client_id) AS sample_id,
             mozfun.map.get_key(
                 b.ping_info.experiments,
                 '{experiment_slug}'
@@ -918,6 +920,7 @@ class Experiment:
         return f"""
             SELECT
                 {analysis_id} AS analysis_id,
+                udf.safe_sample_id({analysis_id}) AS sample_id,
                 JSON_VALUE(event_extra, '$.branch') AS branch,
                 DATE(MIN(submission_timestamp)) AS enrollment_date,
                 COUNT(submission_timestamp) AS num_enrollment_events
@@ -947,6 +950,7 @@ class Experiment:
         return f"""
             SELECT
                 client_id AS analysis_id,
+                udf.safe_sample_id(analysis_id) AS sample_id,
                 JSON_VALUE(event_extra, '$.branch') AS branch,
                 DATE(MIN(submission_timestamp)) AS enrollment_date,
                 COUNT(submission_timestamp) AS num_enrollment_events
@@ -980,6 +984,7 @@ class Experiment:
         return f"""
             SELECT
                 mozfun.map.get_key(e.extra, "nimbus_user_id") AS analysis_id,
+                0 AS sample_id,
                 mozfun.map.get_key(
                     e.extra,
                     'branch'
@@ -1004,6 +1009,7 @@ class Experiment:
         return f"""
         SELECT
             e.analysis_id,
+            udf.safe_sample_id(e.analysis_id) AS sample_id,
             e.branch,
             min(e.submission_date) AS exposure_date,
             COUNT(e.submission_date) AS num_exposure_events
@@ -1039,6 +1045,7 @@ class Experiment:
         return f"""
             SELECT
                 exposures.analysis_id AS analysis_id,
+                udf.safe_sample_id(exposures.analysis_id) AS sample_id,
                 exposures.branch,
                 DATE(MIN(exposures.submission_date)) AS exposure_date,
                 COUNT(exposures.submission_date) AS num_exposure_events
@@ -1077,6 +1084,7 @@ class Experiment:
         return f"""
             SELECT
                 exposures.analysis_id AS analysis_id,
+                udf.safe_sample_id(exposures.analysis_id) AS sample_id,
                 exposures.branch,
                 DATE(MIN(exposures.submission_date)) AS exposure_date,
                 COUNT(exposures.submission_date) AS num_exposure_events

--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -1009,7 +1009,6 @@ class Experiment:
         return f"""
         SELECT
             e.analysis_id,
-            udf.safe_sample_id(e.analysis_id) AS sample_id,
             e.branch,
             min(e.submission_date) AS exposure_date,
             COUNT(e.submission_date) AS num_exposure_events
@@ -1045,7 +1044,6 @@ class Experiment:
         return f"""
             SELECT
                 exposures.analysis_id AS analysis_id,
-                udf.safe_sample_id(exposures.analysis_id) AS sample_id,
                 exposures.branch,
                 DATE(MIN(exposures.submission_date)) AS exposure_date,
                 COUNT(exposures.submission_date) AS num_exposure_events
@@ -1084,7 +1082,6 @@ class Experiment:
         return f"""
             SELECT
                 exposures.analysis_id AS analysis_id,
-                udf.safe_sample_id(exposures.analysis_id) AS sample_id,
                 exposures.branch,
                 DATE(MIN(exposures.submission_date)) AS exposure_date,
                 COUNT(exposures.submission_date) AS num_exposure_events

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1062,6 +1062,7 @@ def test_enrollments_query_analysis_unit(analysis_unit):
     WITH raw_enrollments AS (
 SELECT
     e.{analysis_unit.value} AS analysis_id,
+    udf.safe_sample_id({analysis_unit.value}) AS sample_id,
     `mozfun.map.get_key`(e.event_map_values, 'branch')
         AS branch,
     MIN(e.submission_date) AS enrollment_date,


### PR DESCRIPTION
This should allow us to more easily (and less destructively) change the sampling rate for an experiment by not requiring enrollments to be recomputed.