### PR TITLE
Use _build_exposure_query_glean_events_stream for exposure queries

### DIFF
--- a/src/mozanalysis/experiment.py
+++ b/src/mozanalysis/experiment.py
@@ -810,13 +810,15 @@ class Experiment:
                 raise IncompatibleAnalysisUnit(
                     "Glean exposures currently only support client_id analysis units"
                 )
-            return self._build_exposure_query_glean_event(time_limits, self.app_id)
+            return self._build_exposure_query_glean_events_stream(
+                time_limits, self.app_id
+            )
         elif exposure_query_type == EnrollmentsQueryType.FENIX_FALLBACK:
             if not self.analysis_unit == AnalysisUnit.CLIENT:
                 raise IncompatibleAnalysisUnit(
                     "Fenix fallback exposures currently only support client_id analysis units"  # noqa: E501
                 )
-            return self._build_exposure_query_glean_event(
+            return self._build_exposure_query_glean_events_stream(
                 time_limits, "org_mozilla_firefox"
             )
         elif exposure_query_type == EnrollmentsQueryType.CIRRUS:


### PR DESCRIPTION
Addresses https://github.com/mozilla/jetstream/issues/3186

See discussion in https://mozilla.slack.com/archives/C4D5ZA91B/p1782195139762939, the `events_stream` tables can be used for the exposure queries which results in a lot less data scanned